### PR TITLE
Allows profile file to work on pathmunge-less systems.

### DIFF
--- a/tools/profile.d-usrblackbox.sh
+++ b/tools/profile.d-usrblackbox.sh
@@ -1,2 +1,7 @@
 # Prepend to $PATH.
-pathmunge /usr/blackbox/bin
+
+if type pathmunge > /dev/null 2>&1 ; then
+    pathmunge /usr/blackbox/bin
+elif ! echo $PATH | grep -Eq "(^|:)/usr/blackbox/bin($|:)" ; then
+    PATH=/usr/blackbox/bin:$PATH
+fi


### PR DESCRIPTION
`pathmunge` is a RedHat/CentOS'ism. It isn't available on Arch Linux, for example.

This will check for `pathmunge`'s existence and use it, or fallback to
prepending to the path (when it isn't already there, which is the same behaviour as pathmunge).

My sh-fu isn't the best, so sanity-checking is appreciated.
