### PR TITLE
Puts parens in print call, for python3 compatibility.

### DIFF
--- a/bin/_blackbox_common.sh
+++ b/bin/_blackbox_common.sh
@@ -299,7 +299,7 @@ function vcs_commit_git() {
 function vcs_relative_path() {
   # Usage: vcs_relative_path file
   local name="$1"
-  python -c 'import os ; print os.path.relpath("'$(pwd -P)'/'"$name"'", "'"$REPOBASE"'")'
+  python -c 'import os ; print(os.path.relpath("'$(pwd -P)'/'"$name"'", "'"$REPOBASE"'"))'
 }
 
 


### PR DESCRIPTION
On some OS'es (namely Arch) python is python3. Since you only make a minimal use of python I made the syntax universal (work on both 2 and 3) instead of messing with the paths.
