### PR TITLE
Ensure editor actually gets a filename to work with.

### DIFF
--- a/bin/blackbox_edit
+++ b/bin/blackbox_edit
@@ -20,6 +20,6 @@ for param in """$@""" ; do
     esac
   fi
   blackbox_edit_start "$param"
-  $EDITOR $unencrypted_file
+  $EDITOR $(get_unencrypted_filename $param)
   blackbox_edit_end "$param"
 done


### PR DESCRIPTION
The current implementation assumes that when `blackbox_edit_start` is called, the `$unencrypted_file` variable it creates will be available to the caller. I am near 100% sure that code doesn't and cannot work (at the very least it fails on my machine).

So we call the resolve method directly on the parameter.
