### PR TITLE
Uses umask to avoid creating world-readable files.

### DIFF
--- a/bin/blackbox_postdeploy
+++ b/bin/blackbox_postdeploy
@@ -41,7 +41,7 @@ echo '========== Decrypting new/changed files: START'
 while read unencrypted_file; do
   encrypted_file=$(get_encrypted_filename "$unencrypted_file")
   decrypt_file_overwrite "$encrypted_file" "$unencrypted_file"
-  chmod g+r,o-rwx "$unencrypted_file"
+  chmod g+r "$unencrypted_file"
   if [[ ! -z "$FILE_GROUP" ]]; then
     chgrp $FILE_GROUP "$unencrypted_file"
   fi


### PR DESCRIPTION
Uses `umask` to ensure decrypted files are created without read/write/execute permissions for others. This is better than `chmod`'ing, because the permissions are set _before_ the file contains sensitive info.

Provides an environment variable `DECRYPT_UMASK` to set the `umask` to use. Defaults to `o=`, which means no access for others.

There was a `chmod o-rwx`. I removed it because it's no longer necessary.
