### PR TITLE
Add a call to prepare_keychain in blackbox_update_all_files

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,7 +496,6 @@ git commit -m"Adding key for KEYNAME" pubring.gpg trustdb.gpg blackbox-admins.tx
 Regenerate all encrypted files with the new key:
 
 ```
-gpg --import keyrings/live/pubring.gpg
 blackbox_update_all_files
 git status
 git commit -m"updated encryption" -a

--- a/bin/blackbox_update_all_files
+++ b/bin/blackbox_update_all_files
@@ -15,6 +15,7 @@ if [[ -z $GPG_AGENT_INFO ]]; then
 fi
 
 disclose_admins
+prepare_keychain
 
 echo '========== ENCRYPTED FILES TO BE RE-ENCRYPTED:'
 awk <"$BB_FILES" '{ print "    " $1 ".gpg" }'


### PR DESCRIPTION
This should properly prepare the user's personal keychain with the correct public keys now. 
