### PR TITLE
Update .gitignore when registering new files

### DIFF
--- a/bin/blackbox_register_new_file
+++ b/bin/blackbox_register_new_file
@@ -8,10 +8,11 @@
 # to systems that need the plaintext (unencrypted) versions, run
 # blackbox_postdeploy.sh to decrypt all the files.
 
-# TODO(tlim): Add the unencrypted file to .gitignore
+# TODO(tlim): Add the unencrypted file to .hgignore
 
 set -e
 . _blackbox_common.sh
+_determine_vcs_base_and_type
 
 unencrypted_file=$(get_unencrypted_filename "$1")
 encrypted_file=$(get_encrypted_filename "$1")
@@ -45,6 +46,15 @@ if $SECRETSEXPOSED ; then
 else
   COMMIT_FILES="$BB_FILES $encrypted_file"
 fi
+
+IGNOREFILE=".${VCS_TYPE}ignore"
+if [[ $VCS_TYPE = 'git' ]]; then
+    if ! grep -Fsx >/dev/null "$unencrypted_file" "$IGNOREFILE"; then
+        echo "$unencrypted_file" >>"$IGNOREFILE"
+        COMMIT_FILES="$COMMIT_FILES $IGNOREFILE"
+    fi
+fi
+
 echo 'NOTE: "already tracked!" messages are safe to ignore.'
 vcs_add $BB_FILES $encrypted_file
 vcs_commit "registered in blackbox: ${unencrypted_file}" $COMMIT_FILES


### PR DESCRIPTION
To reduce the risk of accidentally adding plaintext secrets, ignore
registered plaintext files.

Re #10.
