### PR TITLE
List of files to be be shredded now prints filenames

### DIFF
--- a/bin/blackbox_shred_all_files
+++ b/bin/blackbox_shred_all_files
@@ -15,6 +15,7 @@ for i in $(<$BB_FILES) ; do
   unencrypted_file=$(get_unencrypted_filename "$i")
   encrypted_file=$(get_encrypted_filename "$i")
   if [[ -f "$unencrypted_file" ]]; then
+    echo "    $unencrypted_file"
     shred_file "$unencrypted_file"
   fi
 done


### PR DESCRIPTION
The blackbox_shred_all_files looks like it wants to print the names of files in "FILES THAT WILL BE SHREDDED" output, nothing appears. Added an echo of the current file. 
