### PR TITLE
Update rpm_filelist.txt

### DIFF
--- a/tools/rpm_filelist.txt
+++ b/tools/rpm_filelist.txt
@@ -2,6 +2,7 @@ read /etc/profile.d/usrblackbox.sh                tools/profile.d-usrblackbox.sh
 exec /usr/blackbox/bin/_blackbox_common.sh        bin/_blackbox_common.sh
 exec /usr/blackbox/bin/_stack_lib.sh              bin/_stack_lib.sh
 exec /usr/blackbox/bin/blackbox_addadmin          bin/blackbox_addadmin
+exec /usr/blackbox/bin/blackbox_cat             bin/blackbox_cat
 exec /usr/blackbox/bin/blackbox_edit              bin/blackbox_edit
 exec /usr/blackbox/bin/blackbox_edit_end          bin/blackbox_edit_end
 exec /usr/blackbox/bin/blackbox_edit_start        bin/blackbox_edit_start
@@ -10,5 +11,4 @@ exec /usr/blackbox/bin/blackbox_postdeploy        bin/blackbox_postdeploy
 exec /usr/blackbox/bin/blackbox_register_new_file bin/blackbox_register_new_file
 exec /usr/blackbox/bin/blackbox_removeadmin       bin/blackbox_removeadmin
 exec /usr/blackbox/bin/blackbox_shred_all_files   bin/blackbox_shred_all_files
-exec /usr/blackbox/bin/blackbox_start             bin/blackbox_start
 exec /usr/blackbox/bin/blackbox_update_all_files  bin/blackbox_update_all_files


### PR DESCRIPTION
Building of the RPMs with the makefile did not function. In order to build an RPM for the current set of files in bin, I removed blackbox_start and added in blackbox_cat to the rpm_filelists.txt file. 