### PR TITLE
Allow blackbox to run without being in $PATH

### DIFF
--- a/bin/blackbox_addadmin
+++ b/bin/blackbox_addadmin
@@ -9,8 +9,9 @@
 #
 
 set -e
-. _blackbox_common.sh
-. _stack_lib.sh
+blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source ${blackbox_home}/_blackbox_common.sh
+source ${blackbox_home}/_stack_lib.sh
 
 fail_if_not_in_repo
 

--- a/bin/blackbox_cat
+++ b/bin/blackbox_cat
@@ -4,7 +4,8 @@
 # blackbox_cat.sh -- Decrypt a file, cat it, shred it
 #
 set -e
-. _blackbox_common.sh
+blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source ${blackbox_home}/_blackbox_common.sh
 
 for param in """$@""" ; do
   shreddable=0

--- a/bin/blackbox_edit
+++ b/bin/blackbox_edit
@@ -4,7 +4,8 @@
 # blackbox_edit.sh -- Decrypt a file temporarily for edition, then re-encrypts it again
 #
 set -e
-. _blackbox_common.sh
+blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source ${blackbox_home}/_blackbox_common.sh
 
 for param in """$@""" ; do
   unencrypted_file=$(get_unencrypted_filename "$param")

--- a/bin/blackbox_edit_end
+++ b/bin/blackbox_edit_end
@@ -5,7 +5,8 @@
 #
 
 set -e
-. _blackbox_common.sh
+blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source ${blackbox_home}/_blackbox_common.sh
 
 unencrypted_file=$(get_unencrypted_filename "$1")
 encrypted_file=$(get_encrypted_filename "$1")

--- a/bin/blackbox_edit_start
+++ b/bin/blackbox_edit_start
@@ -5,7 +5,8 @@
 #
 
 set -e
-. _blackbox_common.sh
+blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source ${blackbox_home}/_blackbox_common.sh
 
 for param in """$@""" ; do
   unencrypted_file=$(get_unencrypted_filename "$param")

--- a/bin/blackbox_initialize
+++ b/bin/blackbox_initialize
@@ -9,7 +9,8 @@
 #
 
 set -e
-. _blackbox_common.sh
+blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source ${blackbox_home}/_blackbox_common.sh
 
 _determine_vcs_base_and_type  # Sets VCS_TYPE
 

--- a/bin/blackbox_postdeploy
+++ b/bin/blackbox_postdeploy
@@ -14,7 +14,8 @@
 export PATH=/usr/bin:/bin:"$PATH"
 
 set -e
-. _blackbox_common.sh
+blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source ${blackbox_home}/_blackbox_common.sh
 
 if [[ "$1" == "" ]]; then
   FILE_GROUP=""

--- a/bin/blackbox_register_new_file
+++ b/bin/blackbox_register_new_file
@@ -11,7 +11,8 @@
 # TODO(tlim): Add the unencrypted file to .hgignore
 
 set -e
-. _blackbox_common.sh
+blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source ${blackbox_home}/_blackbox_common.sh
 _determine_vcs_base_and_type
 
 unencrypted_file=$(get_unencrypted_filename "$1")

--- a/bin/blackbox_removeadmin
+++ b/bin/blackbox_removeadmin
@@ -10,8 +10,9 @@
 #
 
 set -e
-. _blackbox_common.sh
-. _stack_lib.sh
+blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source ${blackbox_home}/_blackbox_common.sh
+source ${blackbox_home}/_stack_lib.sh
 
 fail_if_not_in_repo
 

--- a/bin/blackbox_shred_all_files
+++ b/bin/blackbox_shred_all_files
@@ -16,7 +16,8 @@
 # have been decrypted for editing, you will see an empty list.
 
 set -e
-. _blackbox_common.sh
+blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source ${blackbox_home}/_blackbox_common.sh
 
 change_to_root
 

--- a/bin/blackbox_update_all_files
+++ b/bin/blackbox_update_all_files
@@ -5,7 +5,8 @@
 #
 
 set -e
-. _blackbox_common.sh
+blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source ${blackbox_home}/_blackbox_common.sh
 
 if [[ -z $GPG_AGENT_INFO ]]; then
   echo 'WARNING: You probably want to run gpg-agent as'

--- a/tools/confidence_test.sh
+++ b/tools/confidence_test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-export PATH="$HOME/gitwork/blackbox/bin":/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin
+blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../bin
+export PATH=${blackbox_home}:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin
 
 . _stack_lib.sh
 


### PR DESCRIPTION
- Fix blackbox commands so that they work when called with absolute paths.
- Fix confidence_test.sh so that it's not hardcoded to a specific dev environment path.

The changes basically look at where the base script is being called from and `source` imports the dependencies.

Tests don't run properly on OS X, but they were able to start and perform some of the basic operations. Paths appear to be working correctly.