### PR TITLE
Fix many bugs for unquote variables.

### DIFF
--- a/bin/_blackbox_common.sh
+++ b/bin/_blackbox_common.sh
@@ -10,13 +10,13 @@
 #   . _blackbox_common.sh
 
 # Where in the VCS repo should the blackbox data be found?
-: ${BLACKBOXDATA:=keyrings/live} ;   # If BLACKBOXDATA not set, set it.
+: "${BLACKBOXDATA:=keyrings/live}" ;   # If BLACKBOXDATA not set, set it.
 
 
 # If $EDITOR is not set, set it to "vi":
-: ${EDITOR:=vi} ;
+: "${EDITOR:=vi}" ;
 
- 
+
 # Outputs a string that is the base directory of this VCS repo.
 # By side-effect, sets the variable VCS_TYPE to either 'git', 'hg',
 # 'svn' or 'unknown'.
@@ -27,19 +27,19 @@ function _determine_vcs_base_and_type() {
     #find topmost dir with .svn sub-dir
     parent=""
     grandparent="."
-    mydir=`pwd`
+    mydir=$(pwd)
     while [ -d "$grandparent/.svn" ]; do
       parent=$grandparent
       grandparent="$parent/.."
     done
 
     if [ ! -z "$parent" ]; then
-      cd $parent
-      echo `pwd`
+      cd "$parent"
+      echo "$(pwd)"
     else
       exit 1
     fi
-    cd $mydir
+    cd "$mydir"
     VCS_TYPE=svn
   elif hg root 2>/dev/null ; then
     # NOTE: hg has to be tested last because it always "succeeds".
@@ -61,7 +61,7 @@ BB_FILES_FILE="blackbox-files.txt"
 BB_FILES="${KEYRINGDIR}/${BB_FILES_FILE}"
 SECRING="${KEYRINGDIR}/secring.gpg"
 PUBRING="${KEYRINGDIR}/pubring.gpg"
-: ${DECRYPT_UMASK:=0022} ;
+: "${DECRYPT_UMASK:=0022}" ;
 # : ${DECRYPT_UMASK:=o=} ;
 
 # Return error if not on cryptlist.
@@ -184,9 +184,9 @@ function decrypt_file() {
   echo "========== EXTRACTING $unencrypted"
 
   old_umask=$(umask)
-  umask $DECRYPT_UMASK
+  umask "$DECRYPT_UMASK"
   gpg -q --decrypt -o "$unencrypted" "$encrypted"
-  umask $old_umask
+  umask "$old_umask"
 }
 
 # Decrypt .gpg file, overwriting unencrypted file if it exists.
@@ -206,12 +206,12 @@ function decrypt_file_overwrite() {
   fi
 
   old_umask=$(umask)
-  umask $DECRYPT_UMASK
+  umask "$DECRYPT_UMASK"
   gpg --yes -q --decrypt -o "$unencrypted" "$encrypted"
-  umask $old_umask
+  umask "$old_umask"
 
   new_hash=$(md5sum_file "$unencrypted")
-  if [[ $old_hash != $new_hash ]]; then
+  if [[ "$old_hash" != "$new_hash" ]]; then
     echo "========== EXTRACTED $unencrypted"
   fi
 }
@@ -250,8 +250,8 @@ function enumerate_subdirs() {
   while read filename; do
     dir=$(dirname "$filename")
     while [[ $dir != '.' && $dir != '/' ]]; do
-      echo $dir
-      dir=$(dirname $dir)
+      echo "$dir"
+      dir=$(dirname "$dir")
     done
   done <"$listfile" | sort -u
 }
@@ -338,7 +338,7 @@ function is_in_svn() {
     echo true
   else
     echo false
-  fi 
+  fi
 }
 
 

--- a/bin/_stack_lib.sh
+++ b/bin/_stack_lib.sh
@@ -79,7 +79,7 @@ function make_tempdir() {
 
   case $(uname -s) in
     Darwin )
-      : ${TMPDIR:=/tmp} ;
+      : "${TMPDIR:=/tmp}" ;
       name=$(mktemp -d -t _stacklib_ )
       ;;
     Linux )

--- a/bin/blackbox_addadmin
+++ b/bin/blackbox_addadmin
@@ -16,17 +16,7 @@ source ${blackbox_home}/_stack_lib.sh
 fail_if_not_in_repo
 
 KEYNAME="$1"
-: ${KEYNAME:?ERROR: First argument must be a keyname (email address)} ;
-
-# The second argument, if present, is the directory to find the GPG keys to be imported.
-if [[ "$2" == "" ]]; then
-  GPGEXPORTOPTIONS=""
-else
-  GPGEXPORTOPTIONS=--homedir="${2}"
-fi
-# TODO(tlim): This could probably be done with GNUPGHOME
-# but that affects all commands; we just want it to affect the key export.
-
+: "${KEYNAME:?ERROR: First argument must be a keyname (email address)}" ;
 
 # Add the email address to the BB_ADMINS file.  Remove any duplicates.
 # The file must exist for sort to act as we expect.
@@ -38,7 +28,16 @@ sort  -fdu -o "$BB_ADMINS" <(echo "$1") "$BB_ADMINS"
 
 # Extract it:
 make_self_deleting_tempfile pubkeyfile
-gpg $GPGEXPORTOPTIONS --export -a "$KEYNAME" >"$pubkeyfile"
+
+# The second argument, if present, is the directory to find the GPG keys to be imported.
+if [[ -z $2 ]]; then
+  gpg --export -a "$KEYNAME" >"$pubkeyfile"
+else
+  # TODO(tlim): This could probably be done with GNUPGHOME
+  # but that affects all commands; we just want it to affect the key export.
+  gpg --homedir="$2" --export -a "$KEYNAME" >"$pubkeyfile"
+fi
+
 if [[ $(wc -l < "$pubkeyfile") = 0 ]]; then
   fail_out "GPG key '$KEYNAME' not found.  Please create it with: gpg --gen-key"
   exit 1

--- a/bin/blackbox_cat
+++ b/bin/blackbox_cat
@@ -5,7 +5,7 @@
 #
 set -e
 blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source ${blackbox_home}/_blackbox_common.sh
+source "${blackbox_home}/_blackbox_common.sh"
 
 for param in """$@""" ; do
   shreddable=0

--- a/bin/blackbox_edit
+++ b/bin/blackbox_edit
@@ -5,7 +5,7 @@
 #
 set -e
 blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source ${blackbox_home}/_blackbox_common.sh
+source "${blackbox_home}/_blackbox_common.sh"
 
 for param in """$@""" ; do
   unencrypted_file=$(get_unencrypted_filename "$param")
@@ -22,6 +22,6 @@ for param in """$@""" ; do
     esac
   fi
   blackbox_edit_start "$param"
-  $EDITOR $(get_unencrypted_filename $param)
+  "$EDITOR" "$(get_unencrypted_filename "$param")"
   blackbox_edit_end "$param"
 done

--- a/bin/blackbox_edit_end
+++ b/bin/blackbox_edit_end
@@ -6,7 +6,7 @@
 
 set -e
 blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source ${blackbox_home}/_blackbox_common.sh
+source "${blackbox_home}/_blackbox_common.sh"
 
 unencrypted_file=$(get_unencrypted_filename "$1")
 encrypted_file=$(get_encrypted_filename "$1")

--- a/bin/blackbox_edit_start
+++ b/bin/blackbox_edit_start
@@ -6,7 +6,7 @@
 
 set -e
 blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source ${blackbox_home}/_blackbox_common.sh
+source "${blackbox_home}/_blackbox_common.sh"
 
 for param in """$@""" ; do
   unencrypted_file=$(get_unencrypted_filename "$param")

--- a/bin/blackbox_initialize
+++ b/bin/blackbox_initialize
@@ -10,7 +10,7 @@
 
 set -e
 blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source ${blackbox_home}/_blackbox_common.sh
+source "${blackbox_home}/_blackbox_common.sh"
 
 _determine_vcs_base_and_type  # Sets VCS_TYPE
 

--- a/bin/blackbox_list_files
+++ b/bin/blackbox_list_files
@@ -5,5 +5,5 @@
 #
 set -e
 blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source ${blackbox_home}/_blackbox_common.sh
+source "${blackbox_home}/_blackbox_common.sh"
 cat "$BB_FILES"

--- a/bin/blackbox_postdeploy
+++ b/bin/blackbox_postdeploy
@@ -15,7 +15,7 @@ export PATH=/usr/bin:/bin:"$PATH"
 
 set -e
 blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source ${blackbox_home}/_blackbox_common.sh
+source "${blackbox_home}/_blackbox_common.sh"
 
 if [[ "$1" == "" ]]; then
   FILE_GROUP=""
@@ -33,7 +33,7 @@ while IFS= read <&99 -r unencrypted_file; do
   decrypt_file_overwrite "$encrypted_file" "$unencrypted_file"
   chmod g+r "$unencrypted_file"
   if [[ ! -z "$FILE_GROUP" ]]; then
-    chgrp $FILE_GROUP "$unencrypted_file"
+    chgrp "$FILE_GROUP" "$unencrypted_file"
   fi
 done 99<"$BB_FILES"
 echo '========== Decrypting new/changed files: DONE'

--- a/bin/blackbox_register_new_file
+++ b/bin/blackbox_register_new_file
@@ -12,13 +12,13 @@
 
 set -e
 blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source ${blackbox_home}/_blackbox_common.sh
+source "${blackbox_home}/_blackbox_common.sh"
 _determine_vcs_base_and_type
 
 unencrypted_file=$(get_unencrypted_filename "$1")
 encrypted_file=$(get_encrypted_filename "$1")
 
-if [[ $1 == $encrypted_file ]]; then
+if [[ "$1" == "$encrypted_file" ]]; then
   echo ERROR: Please only register unencrypted files.
   exit 1
 fi
@@ -34,13 +34,13 @@ encrypt_file "$unencrypted_file" "$encrypted_file"
 add_filename_to_cryptlist "$unencrypted_file"
 
 # Is the unencrypted file already in HG? (ie. are we correcting a bad situation)
-SECRETSEXPOSED=$(is_in_vcs ${unencrypted_file})
+SECRETSEXPOSED=$(is_in_vcs "${unencrypted_file}")
 echo "========== CREATED: ${encrypted_file}"
 echo "========== UPDATING REPO:"
 shred_file "$unencrypted_file"
 
 VCSCMD=$(which_vcs)
-if $SECRETSEXPOSED ; then
+if "$SECRETSEXPOSED" ; then
   vcs_remove "$unencrypted_file"
   vcs_add "$encrypted_file"
   COMMIT_FILES="$BB_FILES $encrypted_file $unencrypted_file"

--- a/bin/blackbox_removeadmin
+++ b/bin/blackbox_removeadmin
@@ -11,13 +11,13 @@
 
 set -e
 blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source ${blackbox_home}/_blackbox_common.sh
-source ${blackbox_home}/_stack_lib.sh
+source "${blackbox_home}/_blackbox_common.sh"
+source "${blackbox_home}/_stack_lib.sh"
 
 fail_if_not_in_repo
 
 KEYNAME="$1"
-: ${KEYNAME:?ERROR: First argument must be a keyname (email address)} ;
+: "${KEYNAME:?ERROR: First argument must be a keyname (email address)}" ;
 
 # Remove the email address from the BB_ADMINS file.
 make_self_deleting_tempfile bbtemp

--- a/bin/blackbox_shred_all_files
+++ b/bin/blackbox_shred_all_files
@@ -17,7 +17,7 @@
 
 set -e
 blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source ${blackbox_home}/_blackbox_common.sh
+source "${blackbox_home}/_blackbox_common.sh"
 
 change_to_root
 

--- a/bin/blackbox_update_all_files
+++ b/bin/blackbox_update_all_files
@@ -6,7 +6,7 @@
 
 set -e
 blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source ${blackbox_home}/_blackbox_common.sh
+source "${blackbox_home}/_blackbox_common.sh"
 
 if [[ -z $GPG_AGENT_INFO ]]; then
   echo 'WARNING: You probably want to run gpg-agent as'
@@ -31,7 +31,7 @@ for i in $(<"$BB_FILES") ; do
     echo "    $unencrypted_file"
   fi
 done
-if $need_warning ; then
+if "$need_warning" ; then
   echo
   echo 'WARNING: This will overwrite any unencrypted files laying about.'
   read -r -p 'Press CTRL-C now to stop. ENTER to continue: '


### PR DESCRIPTION
Fixing many unquote variables leading to some DOS/DDOS attack. Example running:
```
bin/blackbox_addadmin '/*/*/*/*/../../../../*/*/*/*/../../../../*/*/*/*'
```

can make system in heavy weight.