### PR TITLE
Register new file now work with space in filename.

### DIFF
--- a/bin/blackbox_register_new_file
+++ b/bin/blackbox_register_new_file
@@ -43,11 +43,9 @@ VCSCMD=$(which_vcs)
 if "$SECRETSEXPOSED" ; then
   vcs_remove "$unencrypted_file"
   vcs_add "$encrypted_file"
-  COMMIT_FILES="$BB_FILES $encrypted_file $unencrypted_file"
+  COMMIT_FILES=("$BB_FILES" "$encrypted_file" "$unencrypted_file")
 else
-  COMMIT_FILES="$BB_FILES $encrypted_file"
-  # FIXME(tal): This should be an array so that filenames with
-  # spaces aren't a problem.
+  COMMIT_FILES=("$BB_FILES" "$encrypted_file")
 fi
 
 # TODO(tlim): This should be moved to _blackbox_common.sh in a
@@ -57,14 +55,14 @@ if [[ $VCS_TYPE = 'git' ]]; then
   ignored_file="$(echo "$unencrypted_file" |  sed 's/\([\*\?]\)/\\\1/g' | sed 's/^\([!#]\)/\\\1/')"
   if ! grep -Fsx >/dev/null "$ignored_file" "$IGNOREFILE"; then
     echo "$ignored_file" >>"$IGNOREFILE"
-    COMMIT_FILES="$COMMIT_FILES $IGNOREFILE"
+    COMMIT_FILES+=("$IGNOREFILE")
   fi
   vcs_add "$IGNOREFILE"
 fi
 
 echo 'NOTE: "already tracked!" messages are safe to ignore.'
-vcs_add "$BB_FILES" $encrypted_file
-vcs_commit "registered in blackbox: ${unencrypted_file}" $COMMIT_FILES
+vcs_add "$BB_FILES" "$encrypted_file"
+vcs_commit "registered in blackbox: ${unencrypted_file}" "${COMMIT_FILES[@]}"
 echo "========== UPDATING VCS: DONE"
 echo "Local repo updated.  Please push when ready."
 echo "    $VCSCMD push"

--- a/tools/confidence_test.sh
+++ b/tools/confidence_test.sh
@@ -335,6 +335,13 @@ assert_file_missing 'stars*bars?.txt'
 assert_file_exists 'stars*bars?.txt'.gpg
 assert_line_exists 'stars\*bars\?.txt' .gitignore
 
+PHASE 'Bob enrolls stars bars.txt'
+echo A very commented file >'stars bars.txt'
+blackbox_register_new_file 'stars bars.txt'
+assert_file_missing 'stars bars.txt'
+assert_file_exists 'stars bars.txt'.gpg
+assert_line_exists 'stars bars.txt' .gitignore
+
 # TODO(tlim): Add test to make sure that now alice can NOT decrypt.
 
 #


### PR DESCRIPTION
Using array instead of string in blackbox_register_new_file to make it works with filename contains spaces.