### PR TITLE
docs: correct typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ What does this look like to the typical user?
 ================================
 
 *  If you need to, start the GPG Agent: `eval $(gpg-agent --daemon)`
-*  Decrypt the file so it is editable: `blackbox_edit FILENAME`
+*  Decrypt the file so it is editable: `blackbox_edit_start FILENAME`
 *  (You will need to enter your GPG passphrase.)
 *  Edit FILENAME as you desire: `vim FILENAME`
 *  Re-encrypt the file: `blackbox_edit_end FILENAME`


### PR DESCRIPTION
the example flow used blackbox_edit (which uses the $EDITOR) but the author meant blackbox_edit_start (since the next step is editing the file in an external editor)