### PR TITLE
Avoid needing blackbox scripts on $PATH

### DIFF
--- a/bin/blackbox_cat
+++ b/bin/blackbox_cat
@@ -11,7 +11,7 @@ for param in """$@""" ; do
   shreddable=0
   unencrypted_file=$(get_unencrypted_filename "$param")
   if [[ ! -e "$unencrypted_file" ]]; then
-    blackbox_edit_start "$param"
+    "${blackbox_home}/blackbox_edit_start" "$param"
     shreddable=1
   fi
   cat "$unencrypted_file"

--- a/bin/blackbox_edit
+++ b/bin/blackbox_edit
@@ -13,7 +13,7 @@ for param in """$@""" ; do
     read -r -p "Encrypt file $param? (y/n) " ans
     case "$ans" in
       y* | Y*)
-        blackbox_register_new_file "$param"
+        "${blackbox_home}/blackbox_register_new_file" "$param"
         ;;
       *)
         echo 'Skipping...'
@@ -21,7 +21,7 @@ for param in """$@""" ; do
         ;;
     esac
   fi
-  blackbox_edit_start "$param"
+  "${blackbox_home}/blackbox_edit_start" "$param"
   "$EDITOR" "$(get_unencrypted_filename "$param")"
-  blackbox_edit_end "$param"
+  "${blackbox_home}/blackbox_edit_end" "$param"
 done


### PR DESCRIPTION
blackbox_edit and blackbox_cat use other blackbox scripts internally,
but assume that they will be found on $PATH. In testing it's useful to
be able to run these scripts by pathname without first putting them on
$PATH, and all the other scripts work just fine in these circumstances.

This edit fixes this by prefixing all references to other scripts in
blackbox_edit and blackbox_cat with ${blackbox_home}, which is conveniently
set as part of sourcing _blackbox_common.sh.