### PR TITLE
Modify several scripts to support or improve support for filenames with space

### DIFF
--- a/bin/_blackbox_common.sh
+++ b/bin/_blackbox_common.sh
@@ -181,7 +181,7 @@ function decrypt_file() {
   encrypted="$1"
   unencrypted="$2"
 
-  echo "========== EXTRACTING $unencrypted"
+  echo '========== EXTRACTING ''"'$unencrypted'"'
 
   old_umask=$(umask)
   umask "$DECRYPT_UMASK"

--- a/bin/blackbox_edit_end
+++ b/bin/blackbox_edit_end
@@ -10,8 +10,8 @@ source "${blackbox_home}/_blackbox_common.sh"
 
 unencrypted_file=$(get_unencrypted_filename "$1")
 encrypted_file=$(get_encrypted_filename "$1")
-echo ========== PLAINFILE "$unencrypted_file"
-echo ========== ENCRYPTED "$encrypted_file"
+echo ========== PLAINFILE '"'$unencrypted_file'"'
+echo ========== ENCRYPTED '"'$encrypted_file'"'
 
 fail_if_not_on_cryptlist "$unencrypted_file"
 fail_if_not_exists "$unencrypted_file" "No unencrypted version to encrypt!"
@@ -22,6 +22,6 @@ shred_file "$unencrypted_file"
 
 _determine_vcs_base_and_type
 
-echo "========== UPDATED ${encrypted_file}"
+echo ========== UPDATED '"'$encrypted_file'"'
 echo "Likely next step:"
-echo "    $VCS_TYPE commit -m\"${encrypted_file} updated\" $encrypted_file"
+echo "    $VCS_TYPE commit -m\"${encrypted_file} updated\" \"$encrypted_file\""

--- a/bin/blackbox_edit_start
+++ b/bin/blackbox_edit_start
@@ -11,7 +11,7 @@ source "${blackbox_home}/_blackbox_common.sh"
 for param in """$@""" ; do
   unencrypted_file=$(get_unencrypted_filename "$param")
   encrypted_file=$(get_encrypted_filename "$param")
-  echo ========== PLAINFILE "$unencrypted_file"
+  echo ========== PLAINFILE '"'$unencrypted_file'"'
 
   fail_if_not_on_cryptlist "$unencrypted_file"
   fail_if_not_exists "$encrypted_file" "This should not happen."

--- a/bin/blackbox_postdeploy
+++ b/bin/blackbox_postdeploy
@@ -26,6 +26,8 @@ fi
 change_to_vcs_root
 prepare_keychain
 
+OLDIFS=$IFS
+
 # Decrypt:
 echo '========== Decrypting new/changed files: START'
 while IFS= read <&99 -r unencrypted_file; do
@@ -36,4 +38,7 @@ while IFS= read <&99 -r unencrypted_file; do
     chgrp "$FILE_GROUP" "$unencrypted_file"
   fi
 done 99<"$BB_FILES"
+
+IFS=$OLDIFS
+
 echo '========== Decrypting new/changed files: DONE'

--- a/bin/blackbox_shred_all_files
+++ b/bin/blackbox_shred_all_files
@@ -21,14 +21,18 @@ source "${blackbox_home}/_blackbox_common.sh"
 
 change_to_vcs_root
 
+OLDIFS=$IFS
+
 echo '========== FILES BEING SHREDDED:'
-for i in $(<"$BB_FILES") ; do
-  unencrypted_file=$(get_unencrypted_filename "$i")
-  encrypted_file=$(get_encrypted_filename "$i")
+while IFS= read <&99 -r unencrypted_file; do
+  unencrypted_file=$(get_unencrypted_filename "$unencrypted_file")
+  encrypted_file=$(get_encrypted_filename "$unencrypted_file")
   if [[ -f "$unencrypted_file" ]]; then
     echo "    $unencrypted_file"
     shred_file "$unencrypted_file"
   fi
-done
+done 99<"$BB_FILES"
+
+IFS=$OLDIFS
 
 echo '========== DONE.'

--- a/bin/blackbox_update_all_files
+++ b/bin/blackbox_update_all_files
@@ -18,19 +18,23 @@ fi
 disclose_admins
 prepare_keychain
 
+OLDIFS=$IFS
+
 echo '========== ENCRYPTED FILES TO BE RE-ENCRYPTED:'
-awk <"$BB_FILES" '{ print "    " $1 ".gpg" }'
+while IFS= read <&99 -r unencrypted_file; do
+    echo "    $unencrypted_file.gpg"
+done 99<"$BB_FILES"
 
 echo '========== FILES IN THE WAY:'
 need_warning=false
-for i in $(<"$BB_FILES") ; do
-  unencrypted_file=$(get_unencrypted_filename "$i")
-  encrypted_file=$(get_encrypted_filename "$i")
+while IFS= read <&99 -r unencrypted_file; do
+  unencrypted_file=$(get_unencrypted_filename "$unencrypted_file")
+  encrypted_file=$(get_encrypted_filename "$unencrypted_file")
   if [[ -f "$unencrypted_file" ]]; then
     need_warning=true
     echo "    $unencrypted_file"
   fi
-done
+done 99<"$BB_FILES"
 if "$need_warning" ; then
   echo
   echo 'WARNING: This will overwrite any unencrypted files laying about.'
@@ -40,20 +44,25 @@ else
 fi
 
 echo '========== RE-ENCRYPTING FILES:'
-for i in $(<"$BB_FILES") ; do
-  unencrypted_file=$(get_unencrypted_filename "$i")
-  encrypted_file=$(get_encrypted_filename "$i")
-  echo ========== PROCESSING "$unencrypted_file"
+while IFS= read <&99 -r unencrypted_file; do
+  unencrypted_file=$(get_unencrypted_filename "$unencrypted_file")
+  encrypted_file=$(get_encrypted_filename "$unencrypted_file")
+  echo ========== PROCESSING '"'$unencrypted_file'"'
   fail_if_not_on_cryptlist "$unencrypted_file"
   decrypt_file_overwrite "$encrypted_file" "$unencrypted_file"
   encrypt_file "$unencrypted_file" "$encrypted_file"
   shred_file "$unencrypted_file"
-done
+done 99<"$BB_FILES"
 
 fail_if_keychain_has_secrets
 
 echo '========== COMMITING TO VCS:'
-vcs_commit 'Re-encrypted keys' $(awk <"$BB_FILES" '{ print $1 ".gpg" }' )
+while IFS= read <&99 -r unencrypted_file; do
+    vcs_add "$unencrypted_file.gpg"
+done 99<"$BB_FILES"
+vcs_commit 'Re-encrypted keys'
+
+IFS=$OLDIFS
 
 VCSCMD=$(which_vcs)
 echo '========== DONE.'


### PR DESCRIPTION
Some "echo" commands were modified, as some "commit" because of the spaces.
And all "for" loops were replaced by "while" loops to read encrypted files line by line instead of separating on space.
The modifications were inspired by the "blackbox_postdeploy" script content and improved with the rewriting of the "IFS" variable at the end.

Don't hesitate to reply or comment if there is any remark.