### PR TITLE
Modify files loop to improve diff display

### DIFF
--- a/bin/blackbox_diff
+++ b/bin/blackbox_diff
@@ -18,6 +18,7 @@ fi
 prepare_keychain
 
 modified_files=()
+modifications=()
 echo '========== DIFFING FILES: START'
 while IFS= read <&99 -r unencrypted_file; do
   unencrypted_file=$(get_unencrypted_filename "$unencrypted_file")
@@ -26,12 +27,16 @@ while IFS= read <&99 -r unencrypted_file; do
   if [[ -f "$unencrypted_file" ]]; then
     out=$(diff -u <(gpg --yes -q --decrypt "$encrypted_file") "$unencrypted_file" || true)
     if [ "$out" != "" ]; then
-      echo ========== PROCESSING '"'$unencrypted_file'"'
-      echo "$out"
       modified_files+=("$unencrypted_file")
+      modifications+=("$out")
     fi
   fi
 done 99<"$BB_FILES"
+modified_files_number=${#modified_files[@]}
+for (( i=0; i<${modified_files_number}; i++ )); do
+  echo ========== PROCESSING '"'${modified_files[$i]}'"'
+  echo -e "${modifications[$i]}\n"
+done
 echo '========== DIFFING FILES: DONE'
 
 fail_if_keychain_has_secrets


### PR DESCRIPTION
Because gpg displays this kind of stuff:
```
You need a passphrase to unlock the secret key for
user: "John Doe <jdoe@jdoe.com>"
2048-bit RSA key, ID 0123AB01, created 2015-01-01 (main key ID 3456CD23)
```
for each decrypted file if we don't use the `--batch` option (we won't use this option because without a GPG-agent it's impossible to run the script).

So, because it's a very annoying to scroll up between all these error messages, all the diffs have been regrouped in one loop after all the `gpg -d` commands.
It's now very easy to read :)