### PR TITLE
change so editor can have options (eg subl -nw)

### DIFF
--- a/bin/blackbox_edit
+++ b/bin/blackbox_edit
@@ -22,6 +22,6 @@ for param in """$@""" ; do
     esac
   fi
   "${blackbox_home}/blackbox_edit_start" "$param"
-  "$EDITOR" "$(get_unencrypted_filename "$param")"
+  $EDITOR "$(get_unencrypted_filename "$param")"
   "${blackbox_home}/blackbox_edit_end" "$param"
 done


### PR DESCRIPTION
with quotes, bash will assume the string is one command, where one might want more than that

eg `EDITOR=subl -nw`

Without it should work.