### PR TITLE
Fix issue on OS X when creating a temporary file

### DIFF
--- a/bin/_stack_lib.sh
+++ b/bin/_stack_lib.sh
@@ -55,7 +55,7 @@ function make_self_deleting_tempfile() {
   case $(uname -s) in
     Darwin )
       : ${TMPDIR:=/tmp} ;
-      name=$(mktemp -t _stacklib_ )
+      name=$(mktemp -t _stacklib_.XXXXXXX )
       ;;
     Linux )
       name=$(mktemp)


### PR DESCRIPTION
This prevents the `mktemp: too few X's in template ‘_stacklib_’` error message from appearing when adding another admin to blackbox and allows the command to successfully execute.

Related:
rtomayko/shocco#5
http://unix.stackexchange.com/q/87638/63283