### PR TITLE
GnuPG 2.1 keyring default extension is '.kbx'

### DIFF
--- a/bin/_blackbox_common.sh
+++ b/bin/_blackbox_common.sh
@@ -62,7 +62,6 @@ BB_ADMINS="${KEYRINGDIR}/${BB_ADMINS_FILE}"
 BB_FILES_FILE="blackbox-files.txt"
 BB_FILES="${KEYRINGDIR}/${BB_FILES_FILE}"
 SECRING="${KEYRINGDIR}/secring.gpg"
-PUBRING="${KEYRINGDIR}/pubring.gpg"
 : "${DECRYPT_UMASK:=0022}" ;
 # : ${DECRYPT_UMASK:=o=} ;
 
@@ -125,6 +124,14 @@ function fail_if_keychain_has_secrets() {
   fi
 }
 
+function get_pubring_path() {
+  if [[ -f "${KEYRINGDIR}/pubring.gpg" ]]; then
+    echo "${KEYRINGDIR}/pubring.gpg"
+  else
+    echo "${KEYRINGDIR}/pubring.kbx"
+  fi
+}
+
 # Output the unencrypted filename.
 function get_unencrypted_filename() {
   echo $(dirname "$1")/$(basename "$1" .gpg) | sed -e 's#^\./##'
@@ -138,7 +145,7 @@ function get_encrypted_filename() {
 # Prepare keychain for use.
 function prepare_keychain() {
   echo '========== Importing keychain: START'
-  gpg --import "${PUBRING}" 2>&1 | egrep -v 'not changed$'
+  gpg --import "$(get_pubring_path)" 2>&1 | egrep -v 'not changed$'
   echo '========== Importing keychain: DONE'
 }
 

--- a/bin/blackbox_addadmin
+++ b/bin/blackbox_addadmin
@@ -45,10 +45,11 @@ fi
 
 # Import it:
 gpg --no-permission-warning --homedir="$KEYRINGDIR" --import "$pubkeyfile"
-vcs_add "$KEYRINGDIR/pubring.gpg" "$KEYRINGDIR/trustdb.gpg" "$BB_ADMINS"
+pubring_path=$(get_pubring_path)
+vcs_add "$pubring_path" "$KEYRINGDIR/trustdb.gpg" "$BB_ADMINS"
 
 # Make a suggestion:
 echo
 echo
 echo 'NEXT STEP: You need to manually check these in:'
-echo '     ' $VCS_TYPE commit -m\'NEW ADMIN: $KEYNAME\' "$BLACKBOXDATA/pubring.gpg" "$BLACKBOXDATA/trustdb.gpg" "$BLACKBOXDATA/$BB_ADMINS_FILE"
+echo '     ' $VCS_TYPE commit -m\'NEW ADMIN: $KEYNAME\' "$BLACKBOXDATA/$(basename ${pubring_path})" "$BLACKBOXDATA/trustdb.gpg" "$BLACKBOXDATA/$BB_ADMINS_FILE"

--- a/bin/blackbox_initialize
+++ b/bin/blackbox_initialize
@@ -33,6 +33,9 @@ if [[ $VCS_TYPE = "git" || $VCS_TYPE = "hg" ]]; then
   if ! grep -sx >/dev/null 'pubring.gpg~' "$IGNOREFILE" ; then
     echo 'pubring.gpg~' >>"$IGNOREFILE"
   fi
+  if ! grep -sx >/dev/null 'pubring.kbx~' "$IGNOREFILE" ; then
+    echo 'pubring.kbx~' >>"$IGNOREFILE"
+  fi
   if ! grep -sx >/dev/null 'secring.gpg' "$IGNOREFILE" ; then
     echo 'secring.gpg' >>"$IGNOREFILE"
   fi
@@ -40,6 +43,7 @@ elif [[ $VCS_TYPE = "svn" ]]; then
   # add file to svn ignore propset
   IGNOREFILE="";
   svn propset svn:ignore 'pubring.gpg~
+pubring.kbx~
 secring.gpg' .
   svn commit -m "ignore file list"
 fi


### PR DESCRIPTION
Proposed fix for #80. GnuPG 2.1 has a new default keyring format, with a different file extension, `.kbx` instead of `.gpg`.  This fix tries to support both extensions. 