### PR TITLE
Adding blackbox_deregister_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Commands:
 | `blackbox_diff` | Diff decrypted files against their original crypted version |
 | `blackbox_initialize` | Enable blackbox for a GIT or HG repo |
 | `blackbox_register_new_file` | Encrypt a file for the first time |
+|  blackbox_deregister_file  | Remove a file from blackbox |
 | `blackbox_list_files` | List the files maintained by blackbox |
 | `blackbox_decrypt_all_files` | Decrypt all managed files (INTERACTIVE) |
 | `blackbox_postdeploy` | Decrypt all managed files (batch) |
@@ -290,10 +291,9 @@ How to remove a file from the system?
 ============================
 
 This is a manual process. It happens quite rarely.
-
-1. Remove the file ``keyrings/live/blackbox-files.txt``
-2. Remove references from ``.gitignore`` or ``.hgignore``
-3. Use ``git rm`` or ``hg rm`` as expected.
+```
+blackbox_deregister_file path/to/file.name.key
+```
 
 How to indoctrinate a new user into the system?
 ============================

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ blackbox_register_new_file path/to/file.name.key
 How to remove a file from the system?
 ============================
 
-This is a manual process. It happens quite rarely.
+This happens quite rarely, but we've got it covered:
 ```
 blackbox_deregister_file path/to/file.name.key
 ```

--- a/bin/_blackbox_common.sh
+++ b/bin/_blackbox_common.sh
@@ -297,7 +297,7 @@ function vcs_relative_path() {
 function remove_line() {
   local tempfile
 
-  tempfile="${1}.blackbox-temp.${RANDOM}.$$"
+  make_self_deleting_tempfile tempfile
 
   # Ensure source file exists
   touch "$1"
@@ -305,7 +305,6 @@ function remove_line() {
 
   # Using cat+rm instead of cp will preserve permissions/ownership
   cat "$tempfile" > "$1"
-  rm "$tempfile"
 }
 
 # Determine if a file contains a given line

--- a/bin/_blackbox_common.sh
+++ b/bin/_blackbox_common.sh
@@ -351,7 +351,7 @@ function which_vcs() {
 
 # Is this file in the current repo?
 function is_in_vcs() {
-  is_in_$(which_vcs) """$@"""
+  is_in_$(which_vcs) "$@"
 }
 # Mercurial
 function is_in_hg() {
@@ -405,23 +405,23 @@ function is_in_unknown() {
 
 # Add a file to the repo (but don't commit it).
 function vcs_add() {
-  vcs_add_$(which_vcs) """$@"""
+  vcs_add_$(which_vcs) "$@"
 }
 # Mercurial
 function vcs_add_hg() {
-  hg add """$@"""
+  hg add "$@"
 }
 # Git
 function vcs_add_git() {
-  git add """$@"""
+  git add "$@"
 }
 # Subversion
 function vcs_add_svn() {
-  svn add --parents """$@"""
+  svn add --parents "$@"
 }
 # Perfoce
 function vcs_add_p4() {
-  p4 add """$@"""
+  p4 add "$@"
 }
 # No repo
 function vcs_add_unknown() {
@@ -431,23 +431,23 @@ function vcs_add_unknown() {
 
 # Commit a file to the repo
 function vcs_commit() {
-  vcs_commit_$(which_vcs) """$@"""
+  vcs_commit_$(which_vcs) "$@"
 }
 # Mercurial
 function vcs_commit_hg() {
-  hg commit -m"""$@"""
+  hg commit -m"$@"
 }
 # Git
 function vcs_commit_git() {
-  git commit -m"""$@"""
+  git commit -m"$@"
 }
 # Subversion
 function vcs_commit_svn() {
-  svn commit -m"""$@"""
+  svn commit -m"$@"
 }
 # Perforce
 function vcs_commit_p4() {
-  p4 submit -d """$@"""
+  p4 submit -d "$@"
 }
 # No repo
 function vcs_commit_unknown() {
@@ -458,23 +458,23 @@ function vcs_commit_unknown() {
 # Remove file from repo, even if it was deleted locally already.
 # If it doesn't exist yet in the repo, it should be a no-op.
 function vcs_remove() {
-  vcs_remove_$(which_vcs) """$@"""
+  vcs_remove_$(which_vcs) "$@"
 }
 # Mercurial
 function vcs_remove_hg() {
-  hg rm -A -- """$@"""
+  hg rm -A -- "$@"
 }
 # Git
 function vcs_remove_git() {
-  git rm --ignore-unmatch -f -- """$@"""
+  git rm --ignore-unmatch -f -- "$@"
 }
 # Subversion
 function vcs_remove_svn() {
-  svn delete """$@"""
+  svn delete "$@"
 }
 # Perforce
 function vcs_remove_p4() {
-  p4 delete """$@"""
+  p4 delete "$@"
 }
 # No repo
 function vcs_remove_unknown() {

--- a/bin/_stack_lib.sh
+++ b/bin/_stack_lib.sh
@@ -11,13 +11,13 @@
 
 function debugmsg() {
   # Log to stderr.
-  echo 1>&2 LOG: """$@"""
+  echo 1>&2 LOG: "$@"
   :
 }
 
 function logit() {
   # Log to stderr.
-  echo 1>&2 LOG: """$@"""
+  echo 1>&2 LOG: "$@"
 }
 
 function fail_out() {

--- a/bin/blackbox_cat
+++ b/bin/blackbox_cat
@@ -7,7 +7,7 @@ set -e
 blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source "${blackbox_home}/_blackbox_common.sh"
 
-for param in """$@""" ; do
+for param in "$@" ; do
   shreddable=0
   unencrypted_file=$(get_unencrypted_filename "$param")
   if [[ ! -e "$unencrypted_file" ]]; then

--- a/bin/blackbox_deregister_file
+++ b/bin/blackbox_deregister_file
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+#
+# blackbox_deregister_file -- Remove a file from the blackbox system.
+#
+# Takes an encrypted file and removes it from the blackbox system.  The
+# encrypted file will also be removed from the filesystem.
+
+set -e
+blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source "${blackbox_home}/_blackbox_common.sh"
+_determine_vcs_base_and_type
+
+unencrypted_file=$(get_unencrypted_filename "$1")
+encrypted_file=$(get_encrypted_filename "$1")
+
+if [[ "$1" == "$unencrypted_file" ]]; then
+  echo ERROR: Please only deregister encrypted files.
+  exit 1
+fi
+
+echo ========== PLAINFILE "$unencrypted_file"
+echo ========== ENCRYPTED "$encrypted_file"
+
+fail_if_not_exists "$encrypted_file" "Please specify an existing file."
+
+prepare_keychain
+remove_filename_from_cryptlist "$unencrypted_file"
+vcs_notice "$unencrypted_file"
+git rm "$encrypted_file"
+vcs_remove "$BB_FILES"
+
+vcs_commit "Removing from blackbox: ${unencrypted_file}"
+echo "========== UPDATING VCS: DONE"
+echo "Local repo updated.  Please push when ready."
+echo "    $(which_vcs) push"

--- a/bin/blackbox_deregister_file
+++ b/bin/blackbox_deregister_file
@@ -27,7 +27,6 @@ fail_if_not_exists "$encrypted_file" "Please specify an existing file."
 prepare_keychain
 remove_filename_from_cryptlist "$unencrypted_file"
 vcs_notice "$unencrypted_file"
-git rm "$encrypted_file"
 vcs_remove "$BB_FILES"
 
 vcs_commit "Removing from blackbox: ${unencrypted_file}"

--- a/bin/blackbox_edit
+++ b/bin/blackbox_edit
@@ -7,7 +7,7 @@ set -e
 blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source "${blackbox_home}/_blackbox_common.sh"
 
-for param in """$@""" ; do
+for param in "$@" ; do
   unencrypted_file=$(get_unencrypted_filename "$param")
   if  ! is_on_cryptlist "$param" && ! is_on_cryptlist "$unencrypted_file" ; then
     read -r -p "Encrypt file $param? (y/n) " ans

--- a/bin/blackbox_edit_start
+++ b/bin/blackbox_edit_start
@@ -8,7 +8,7 @@ set -e
 blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source "${blackbox_home}/_blackbox_common.sh"
 
-for param in """$@""" ; do
+for param in "$@" ; do
   unencrypted_file=$(get_unencrypted_filename "$param")
   encrypted_file=$(get_encrypted_filename "$param")
   echo >&2 ========== PLAINFILE '"'$unencrypted_file'"'

--- a/bin/blackbox_initialize
+++ b/bin/blackbox_initialize
@@ -25,28 +25,7 @@ fi
 change_to_vcs_root
 
 echo VCS_TYPE: $VCS_TYPE
-
-if [[ $VCS_TYPE = "git" || $VCS_TYPE = "hg" ]]; then
-  # Update .gitignore or .hgignore
-
-  IGNOREFILE="${REPOBASE}/.${VCS_TYPE}ignore"
-  if ! grep -sx >/dev/null 'pubring.gpg~' "$IGNOREFILE" ; then
-    echo 'pubring.gpg~' >>"$IGNOREFILE"
-  fi
-  if ! grep -sx >/dev/null 'pubring.kbx~' "$IGNOREFILE" ; then
-    echo 'pubring.kbx~' >>"$IGNOREFILE"
-  fi
-  if ! grep -sx >/dev/null 'secring.gpg' "$IGNOREFILE" ; then
-    echo 'secring.gpg' >>"$IGNOREFILE"
-  fi
-elif [[ $VCS_TYPE = "svn" ]]; then
-  # add file to svn ignore propset
-  IGNOREFILE="";
-  svn propset svn:ignore 'pubring.gpg~
-pubring.kbx~
-secring.gpg' .
-  svn commit -m "ignore file list"
-fi
+vcs_ignore keyrings/live/pubring.gpg~ keyrings/live/pubring.kbx~ keyrings/live/secring.gpg
 
 # Make directories
 mkdir -p "${KEYRINGDIR}"

--- a/bin/blackbox_register_new_file
+++ b/bin/blackbox_register_new_file
@@ -8,8 +8,6 @@
 # to systems that need the plaintext (unencrypted) versions, run
 # blackbox_postdeploy.sh to decrypt all the files.
 
-# TODO(tlim): Add the unencrypted file to .hgignore
-
 set -e
 blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source "${blackbox_home}/_blackbox_common.sh"

--- a/bin/blackbox_register_new_file
+++ b/bin/blackbox_register_new_file
@@ -11,7 +11,6 @@
 set -e
 blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source "${blackbox_home}/_blackbox_common.sh"
-_determine_vcs_base_and_type
 
 unencrypted_file=$(get_unencrypted_filename "$1")
 encrypted_file=$(get_encrypted_filename "$1")
@@ -37,7 +36,6 @@ echo "========== CREATED: ${encrypted_file}"
 echo "========== UPDATING REPO:"
 shred_file "$unencrypted_file"
 
-VCSCMD=$(which_vcs)
 if "$SECRETSEXPOSED" ; then
   vcs_remove "$unencrypted_file"
   vcs_add "$encrypted_file"
@@ -46,23 +44,10 @@ else
   COMMIT_FILES=("$BB_FILES" "$encrypted_file")
 fi
 
-# TODO(tlim): This should be moved to _blackbox_common.sh in a
-# VCS-independent way.
-IGNOREFILE="${REPOBASE}/.${VCS_TYPE}ignore"
-if [[ $VCS_TYPE = 'git' ]]; then
-  relfile="$(vcs_relative_path "$unencrypted_file")"
-  relfileb="${relfile/\$\//}"
-  ignored_file="$(echo "${relfileb}" |  sed 's/\([\*\?]\)/\\\1/g' | sed 's/^\([!#]\)/\\\1/')"
-  if ! grep -Fsx >/dev/null "$ignored_file" "$IGNOREFILE"; then
-    echo "$ignored_file" >>"$IGNOREFILE"
-    COMMIT_FILES+=("$IGNOREFILE")
-  fi
-  vcs_add "$IGNOREFILE"
-fi
-
+vcs_ignore "$unencrypted_file"
 echo 'NOTE: "already tracked!" messages are safe to ignore.'
 vcs_add "$BB_FILES" "$encrypted_file"
 vcs_commit "registered in blackbox: ${unencrypted_file}" "${COMMIT_FILES[@]}"
 echo "========== UPDATING VCS: DONE"
 echo "Local repo updated.  Please push when ready."
-echo "    $VCSCMD push"
+echo "    $(which_vcs) push"

--- a/bin/blackbox_removeadmin
+++ b/bin/blackbox_removeadmin
@@ -20,9 +20,7 @@ KEYNAME="$1"
 : "${KEYNAME:?ERROR: First argument must be a keyname (email address)}" ;
 
 # Remove the email address from the BB_ADMINS file.
-make_self_deleting_tempfile bbtemp
-cp "$BB_ADMINS" "$bbtemp"
-fgrep -v -x "$KEYNAME" <"$bbtemp" >"$BB_ADMINS"
+remove_line "$BB_ADMINS" "$KEYNAME"
 
 # Make a suggestion:
 echo


### PR DESCRIPTION
This is to provide the utility requested by myself in issue #84.

There are a few separate commits.  Two are related to cleanup.  One is just rewording.  The meat of the changes happens in 01e6810, where I pulled code from `blackbox_register_new_file` and `blackbox_initialize` and made the `vcs_ignore` and `vcs_notice` functions.  I split up the commits so you could pick and choose what you'd like to see in the project.

I wrote a script that registered and deregistered files while I was working on it.  I've tested with git only.  hg should work and svn commands were delivered courtesy of Google.  p4 looks like it supports ignore files but only when you set an environment variable.