### PR TITLE
Always setting BLACKBOX_HOME

### DIFF
--- a/bin/_blackbox_common.sh
+++ b/bin/_blackbox_common.sh
@@ -7,7 +7,13 @@
 # Usage:
 #
 #   set -e
-#   . _blackbox_common.sh
+#   source "${0%/*}/_blackbox_common.sh"
+
+# Load additional useful functions
+source "${0%/*}"/_stack_lib.sh
+
+# Where are we?
+: "${BLACKBOX_HOME:=$(cd "${0%/*}" ; pwd)}" ;
 
 # Where in the VCS repo should the blackbox data be found?
 : "${BLACKBOXDATA:=keyrings/live}" ;   # If BLACKBOXDATA not set, set it.

--- a/bin/blackbox_addadmin
+++ b/bin/blackbox_addadmin
@@ -9,9 +9,7 @@
 #
 
 set -e
-blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source ${blackbox_home}/_blackbox_common.sh
-source ${blackbox_home}/_stack_lib.sh
+source "${0%/*}/_blackbox_common.sh"
 
 fail_if_not_in_repo
 

--- a/bin/blackbox_cat
+++ b/bin/blackbox_cat
@@ -4,14 +4,13 @@
 # blackbox_cat -- Decrypt a file, cat it, shred it
 #
 set -e
-blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source "${blackbox_home}/_blackbox_common.sh"
+source "${0%/*}/_blackbox_common.sh"
 
 for param in "$@" ; do
   shreddable=0
   unencrypted_file=$(get_unencrypted_filename "$param")
   if [[ ! -e "$unencrypted_file" ]]; then
-    "${blackbox_home}/blackbox_edit_start" "$param"
+    "${BLACKBOX_HOME}/blackbox_edit_start" "$param"
     shreddable=1
   fi
   cat "$unencrypted_file"

--- a/bin/blackbox_deregister_file
+++ b/bin/blackbox_deregister_file
@@ -7,8 +7,7 @@
 # encrypted file will also be removed from the filesystem.
 
 set -e
-blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source "${blackbox_home}/_blackbox_common.sh"
+source "${0%/*}/_blackbox_common.sh"
 _determine_vcs_base_and_type
 
 unencrypted_file=$(get_unencrypted_filename "$1")

--- a/bin/blackbox_diff
+++ b/bin/blackbox_diff
@@ -5,8 +5,7 @@
 #
 
 set -e
-blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source "${blackbox_home}/_blackbox_common.sh"
+source "${0%/*}/_blackbox_common.sh"
 
 if [[ -z $GPG_AGENT_INFO ]]; then
   echo 'WARNING: You probably want to run gpg-agent as'

--- a/bin/blackbox_edit
+++ b/bin/blackbox_edit
@@ -4,8 +4,7 @@
 # blackbox_edit -- Decrypt a file temporarily for edition, then re-encrypts it again
 #
 set -e
-blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source "${blackbox_home}/_blackbox_common.sh"
+source "${0%/*}/_blackbox_common.sh"
 
 for param in "$@" ; do
   unencrypted_file=$(get_unencrypted_filename "$param")
@@ -13,7 +12,7 @@ for param in "$@" ; do
     read -r -p "Encrypt file $param? (y/n) " ans
     case "$ans" in
       y* | Y*)
-        "${blackbox_home}/blackbox_register_new_file" "$param"
+        "${BLACKBOX_HOME}/blackbox_register_new_file" "$param"
         ;;
       *)
         echo 'Skipping...'
@@ -21,7 +20,7 @@ for param in "$@" ; do
         ;;
     esac
   fi
-  "${blackbox_home}/blackbox_edit_start" "$param"
+  "${BLACKBOX_HOME}/blackbox_edit_start" "$param"
   "$EDITOR" "$(get_unencrypted_filename "$param")"
-  "${blackbox_home}/blackbox_edit_end" "$param"
+  "${BLACKBOX_HOME}/blackbox_edit_end" "$param"
 done

--- a/bin/blackbox_edit_end
+++ b/bin/blackbox_edit_end
@@ -5,8 +5,7 @@
 #
 
 set -e
-blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source "${blackbox_home}/_blackbox_common.sh"
+source "${0%/*}/_blackbox_common.sh"
 
 unencrypted_file=$(get_unencrypted_filename "$1")
 encrypted_file=$(get_encrypted_filename "$1")

--- a/bin/blackbox_edit_start
+++ b/bin/blackbox_edit_start
@@ -5,8 +5,7 @@
 #
 
 set -e
-blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source "${blackbox_home}/_blackbox_common.sh"
+source "${0%/*}/_blackbox_common.sh"
 
 for param in "$@" ; do
   unencrypted_file=$(get_unencrypted_filename "$param")

--- a/bin/blackbox_initialize
+++ b/bin/blackbox_initialize
@@ -9,8 +9,7 @@
 #
 
 set -e
-blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source "${blackbox_home}/_blackbox_common.sh"
+source "${0%/*}/_blackbox_common.sh"
 
 _determine_vcs_base_and_type  # Sets VCS_TYPE
 

--- a/bin/blackbox_list_files
+++ b/bin/blackbox_list_files
@@ -4,6 +4,5 @@
 # blackbox_list_files -- List files that black box is tracking
 #
 set -e
-blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source "${blackbox_home}/_blackbox_common.sh"
+source "${0%/*}/_blackbox_common.sh"
 cat "$BB_FILES"

--- a/bin/blackbox_postdeploy
+++ b/bin/blackbox_postdeploy
@@ -14,8 +14,7 @@
 export PATH=/usr/bin:/bin:"$PATH"
 
 set -e
-blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source "${blackbox_home}/_blackbox_common.sh"
+source "${0%/*}/_blackbox_common.sh"
 
 if [[ "$1" == "" ]]; then
   FILE_GROUP=""

--- a/bin/blackbox_register_new_file
+++ b/bin/blackbox_register_new_file
@@ -9,8 +9,7 @@
 # blackbox_postdeploy.sh to decrypt all the files.
 
 set -e
-blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source "${blackbox_home}/_blackbox_common.sh"
+source "${0%/*}/_blackbox_common.sh"
 
 unencrypted_file=$(get_unencrypted_filename "$1")
 encrypted_file=$(get_encrypted_filename "$1")

--- a/bin/blackbox_removeadmin
+++ b/bin/blackbox_removeadmin
@@ -10,9 +10,7 @@
 #
 
 set -e
-blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source "${blackbox_home}/_blackbox_common.sh"
-source "${blackbox_home}/_stack_lib.sh"
+source "${0%/*}/_blackbox_common.sh"
 
 fail_if_not_in_repo
 

--- a/bin/blackbox_shred_all_files
+++ b/bin/blackbox_shred_all_files
@@ -16,8 +16,7 @@
 # have been decrypted for editing, you will see an empty list.
 
 set -e
-blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source "${blackbox_home}/_blackbox_common.sh"
+source "${0%/*}/_blackbox_common.sh"
 
 change_to_vcs_root
 

--- a/bin/blackbox_update_all_files
+++ b/bin/blackbox_update_all_files
@@ -5,8 +5,7 @@
 #
 
 set -e
-blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source "${blackbox_home}/_blackbox_common.sh"
+source "${0%/*}/_blackbox_common.sh"
 
 if [[ -z $GPG_AGENT_INFO ]]; then
   echo 'WARNING: You probably want to run gpg-agent as'

--- a/bin/blackbox_whatsnew
+++ b/bin/blackbox_whatsnew
@@ -4,8 +4,8 @@
 # blackbox_whatsnew - show what has changed in the last commit for a given file
 #
 
-blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source "${blackbox_home}/_blackbox_common.sh"
+set -e
+source "${0%/*}/_blackbox_common.sh"
 
 if [[ $# -ne 1 ]]
 then
@@ -39,7 +39,7 @@ cat_commit()
   git checkout $COMMIT $FILE
   echo "[$COMMIT] $FILE"
   echo "---------------------"
-  "${blackbox_home}/blackbox_cat" $FILE | sed '/========== PLAINFILE/,/========== EXTRACTING/d'
+  "${BLACKBOX_HOME}/blackbox_cat" $FILE | sed '/========== PLAINFILE/,/========== EXTRACTING/d'
 }
 
 CURR_CONTENT=`cat_commit $CURR_COMMIT`


### PR DESCRIPTION
One really important thing to note is that this fixes a bug where _blackbox_common.sh did not load _stack_lib.sh.

----

This makes the beginning of all files the same and a little simpler.

`${0%/*}` turns "/home/user/repository/bin/blackbox_edit" into
"/home/user/repository/bin", exactly like basename but without eating a
process.

Because other scripts needed `$blackbox_home` I made this into a
standardard variable that's always available.

This also loads _stack_lib.sh always because _blackbox_common.sh
requires it.