### PR TITLE
Deregister was removing the blackbox-list.txt file

### DIFF
--- a/bin/blackbox_deregister_file
+++ b/bin/blackbox_deregister_file
@@ -26,7 +26,9 @@ fail_if_not_exists "$encrypted_file" "Please specify an existing file."
 prepare_keychain
 remove_filename_from_cryptlist "$unencrypted_file"
 vcs_notice "$unencrypted_file"
-vcs_remove "$BB_FILES"
+vcs_remove "$unencrypted_file"
+vcs_remove "$encrypted_file"
+vcs_add "$BB_FILES"
 
 vcs_commit "Removing from blackbox: ${unencrypted_file}"
 echo "========== UPDATING VCS: DONE"


### PR DESCRIPTION
In the process of testing blackbox out for our own use I found that the deregister command wipes out the entire keyrings/live/blackbox-files.txt .

This removes that action and instead adds the file to be committed to git.  I also added some removes of the unencrypted file and the encrypted file.  However if that wasn't what was intended I can remove that bit.