### PR TITLE
Fixed initialization

### DIFF
--- a/bin/_blackbox_common.sh
+++ b/bin/_blackbox_common.sh
@@ -469,6 +469,19 @@ function vcs_remove_unknown() {
   :
 }
 
+# Get a path for the ignore file if possible in current vcs
+function vcs_ignore_file_path() {
+  vcs_ignore_file_path_$VCS_TYPE
+}
+# Mercurial
+function vcs_ignore_file_path_hg() {
+  echo "$REPOBASE/.hgignore"
+}
+# Git
+function vcs_ignore_file_path_git() {
+  echo "$REPOBASE/.gitignore"
+}
+
 
 # Ignore a file in a repo.  If it was already ignored, this is a no-op.
 function vcs_ignore() {
@@ -479,11 +492,11 @@ function vcs_ignore() {
 }
 # Mercurial
 function vcs_ignore_hg() {
-  vcs_ignore_generic_file "$REPOBASE/.hgignore" "$file"
+  vcs_ignore_generic_file "$(vcs_ignore_file_path)" "$file"
 }
 # Git
 function vcs_ignore_git() {
-  vcs_ignore_generic_file "$REPOBASE/.gitignore" "$file"
+  vcs_ignore_generic_file "$(vcs_ignore_file_path)" "$file"
 }
 # Subversion
 function vcs_ignore_svn() {

--- a/bin/blackbox_initialize
+++ b/bin/blackbox_initialize
@@ -28,7 +28,10 @@ vcs_ignore keyrings/live/pubring.gpg~ keyrings/live/pubring.kbx~ keyrings/live/s
 mkdir -p "${KEYRINGDIR}"
 vcs_add "${KEYRINGDIR}"
 touch "$BLACKBOXDATA/$BB_ADMINS_FILE" "$BLACKBOXDATA/$BB_FILES_FILE"
-vcs_add "$IGNOREFILE" "$BLACKBOXDATA/$BB_ADMINS_FILE" "$BLACKBOXDATA/$BB_FILES_FILE"
+vcs_add "$BLACKBOXDATA/$BB_ADMINS_FILE" "$BLACKBOXDATA/$BB_FILES_FILE"
+
+IGNOREFILE="$(vcs_ignore_file_path)"
+test -f "$IGNOREFILE" && vcs_add "$IGNOREFILE"
 
 # Make a suggestion:
 echo


### PR DESCRIPTION
IGNOREFILE variable no longer exists which resulted in calling "vcs_add <empty
string>" command adding all untracked files when blackbox_initialize is called