### PR TITLE
Allow overriding gpg command

### DIFF
--- a/bin/_blackbox_common.sh
+++ b/bin/_blackbox_common.sh
@@ -22,6 +22,8 @@ source "${0%/*}"/_stack_lib.sh
 # If $EDITOR is not set, set it to "vi":
 : "${EDITOR:=vi}" ;
 
+# Allow overriding gpg command
+: "${GPG:=gpg}" ;
 
 # Set REPOBASE to the top of the repository
 # Set VCS_TYPE to 'git', 'hg', 'svn' or 'unknown'
@@ -140,7 +142,7 @@ function get_encrypted_filename() {
 # Prepare keychain for use.
 function prepare_keychain() {
   echo '========== Importing keychain: START' >&2
-  gpg --import "$(get_pubring_path)" 2>&1 | egrep -v 'not changed$' >&2
+  $GPG --import "$(get_pubring_path)" 2>&1 | egrep -v 'not changed$' >&2
   echo '========== Importing keychain: DONE' >&2
 }
 
@@ -186,7 +188,7 @@ function encrypt_file() {
   encrypted="$2"
 
   echo "========== Encrypting: $unencrypted" >&2
-  gpg --use-agent --yes --trust-model=always --encrypt -o "$encrypted"  $(awk '{ print "-r" $1 }' < "$BB_ADMINS") "$unencrypted" >&2
+  $GPG --use-agent --yes --trust-model=always --encrypt -o "$encrypted"  $(awk '{ print "-r" $1 }' < "$BB_ADMINS") "$unencrypted" >&2
   echo '========== Encrypting: DONE' >&2
 }
 
@@ -202,7 +204,7 @@ function decrypt_file() {
 
   old_umask=$(umask)
   umask "$DECRYPT_UMASK"
-  gpg --use-agent -q --decrypt -o "$unencrypted" "$encrypted" >&2
+  $GPG --use-agent -q --decrypt -o "$unencrypted" "$encrypted" >&2
   umask "$old_umask"
 }
 
@@ -224,7 +226,7 @@ function decrypt_file_overwrite() {
 
   old_umask=$(umask)
   umask "$DECRYPT_UMASK"
-  gpg --use-agent --yes -q --decrypt -o "$unencrypted" "$encrypted" >&2
+  $GPG --use-agent --yes -q --decrypt -o "$unencrypted" "$encrypted" >&2
   umask "$old_umask"
 
   new_hash=$(md5sum_file "$unencrypted")

--- a/bin/blackbox_addadmin
+++ b/bin/blackbox_addadmin
@@ -29,20 +29,20 @@ make_self_deleting_tempfile pubkeyfile
 
 # The second argument, if present, is the directory to find the GPG keys to be imported.
 if [[ -z $2 ]]; then
-  gpg --export -a "$KEYNAME" >"$pubkeyfile"
+  $GPG --export -a "$KEYNAME" >"$pubkeyfile"
 else
   # TODO(tlim): This could probably be done with GNUPGHOME
   # but that affects all commands; we just want it to affect the key export.
-  gpg --homedir="$2" --export -a "$KEYNAME" >"$pubkeyfile"
+  $GPG --homedir="$2" --export -a "$KEYNAME" >"$pubkeyfile"
 fi
 
 if [[ $(wc -l < "$pubkeyfile") = 0 ]]; then
-  fail_out "GPG key '$KEYNAME' not found.  Please create it with: gpg --gen-key"
+  fail_out "GPG key '$KEYNAME' not found.  Please create it with: $GPG --gen-key"
   exit 1
 fi
 
 # Import it:
-gpg --no-permission-warning --homedir="$KEYRINGDIR" --import "$pubkeyfile"
+$GPG --no-permission-warning --homedir="$KEYRINGDIR" --import "$pubkeyfile"
 pubring_path=$(get_pubring_path)
 vcs_add "$pubring_path" "$KEYRINGDIR/trustdb.gpg" "$BB_ADMINS"
 

--- a/bin/blackbox_diff
+++ b/bin/blackbox_diff
@@ -24,7 +24,7 @@ while IFS= read <&99 -r unencrypted_file; do
   encrypted_file=$(get_encrypted_filename "$unencrypted_file")
   fail_if_not_on_cryptlist "$unencrypted_file"
   if [[ -f "$unencrypted_file" ]]; then
-    out=$(diff -u <(gpg --yes -q --decrypt "$encrypted_file") "$unencrypted_file" || true)
+    out=$(diff -u <($GPG --yes -q --decrypt "$encrypted_file") "$unencrypted_file" || true)
     if [ "$out" != "" ]; then
       modified_files+=("$unencrypted_file")
       modifications+=("$out")


### PR DESCRIPTION
This is particular useful on OS X when gnupg version 2 is installed with brew
which installs it as gpg2