### PR TITLE
added quotes to fix linting $BLACKBOX_HOME Linting in _blockbox_common.sh

### DIFF
--- a/bin/_blackbox_common.sh
+++ b/bin/_blackbox_common.sh
@@ -13,7 +13,7 @@
 source "${0%/*}"/_stack_lib.sh
 
 # Where are we?
-: "${BLACKBOX_HOME:=$(cd "${0%/*}" ; pwd)}" ;
+: "${BLACKBOX_HOME:="$(cd "${0%/*}" ; pwd)"}" ;
 
 # Where in the VCS repo should the blackbox data be found?
 : "${BLACKBOXDATA:=keyrings/live}" ;   # If BLACKBOXDATA not set, set it.


### PR DESCRIPTION
Small change that correctly lints the file in SublimeText.  

It's a subtle change, so I wanted to separate the pull request.