### PR TITLE
File permissions now persits when decrypting.

### DIFF
--- a/bin/blackbox_postdeploy
+++ b/bin/blackbox_postdeploy
@@ -30,8 +30,9 @@ echo '========== Decrypting new/changed files: START'
 while IFS= read <&99 -r unencrypted_file; do
   encrypted_file=$(get_encrypted_filename "$unencrypted_file")
   decrypt_file_overwrite "$encrypted_file" "$unencrypted_file"
-  chmod g+r "$unencrypted_file"
+  chmod --reference "$encrypted_file" "$unencrypted_file"
   if [[ ! -z "$FILE_GROUP" ]]; then
+    chmod g+r "$unencrypted_file"
     chgrp "$FILE_GROUP" "$unencrypted_file"
   fi
 done 99<"$BB_FILES"


### PR DESCRIPTION
Related to issue https://github.com/StackExchange/blackbox/issues/100

File permissions of the encrypted files now persits over the encrypted files. Decrypted files had the system default permissions for new files which was a security issue, especially if the others class resulted with read access after the file creation.

I've also moved `chmod g+r` only when an optional group was provided. Security wise we want to keep the same permissions as the encrypted file by default and have everthing opt-in, not opt-out. 

