### PR TITLE
Support having an $EDITOR value with arguments

### DIFF
--- a/bin/blackbox_edit
+++ b/bin/blackbox_edit
@@ -27,7 +27,7 @@ for param in "$@" ; do
     esac
   fi
   "${BLACKBOX_HOME}/blackbox_edit_start" "$unencrypted_file"
-  "$EDITOR" "$(get_unencrypted_filename "$unencrypted_file")"
+  $EDITOR "$(get_unencrypted_filename "$unencrypted_file")"
   "${BLACKBOX_HOME}/blackbox_edit_end" "$unencrypted_file"
 
 done


### PR DESCRIPTION
If a user has $EDITOR set to e.g "subl --wait", then "$EDITOR" (with
quotes) will fail with error "command not found: subl --wait". In other
words, it looks for an executable containing the space and the --wait in
it.

Simply removing the quotes seems to work fine.