### PR TITLE
Be consistent when creating tmpfiles in stacklib

### DIFF
--- a/bin/_stack_lib.sh
+++ b/bin/_stack_lib.sh
@@ -76,7 +76,7 @@ function create_self_deleting_tempdir() {
   case $(uname -s) in
     Darwin )
       : ${TMPDIR:=/tmp} ;
-      filename=$(mktemp -d -t _stacklib_ )
+      filename=$(mktemp -d -t _stacklib_.XXXXXXXX )
       ;;
     Linux | CYGWIN* )
       filename=$(mktemp -d)
@@ -100,7 +100,7 @@ function make_self_deleting_tempfile() {
   case $(uname -s) in
     Darwin )
       : ${TMPDIR:=/tmp} ;
-      name=$(mktemp -t _stacklib_ )
+      name=$(mktemp -t _stacklib_.XXXXXXXX )
       ;;
     Linux | CYGWIN* )
       name=$(mktemp)
@@ -122,7 +122,7 @@ function make_tempdir() {
   case $(uname -s) in
     Darwin )
       : ${TMPDIR:=/tmp} ;
-      name=$(mktemp -d -t _stacklib_ )
+      name=$(mktemp -d -t _stacklib_.XXXXXXXX )
       ;;
     Linux | CYGWIN* )
       name=$(mktemp -d)


### PR DESCRIPTION
Use same naming scheme as elsewhere when creating tempfiles.

This fixes deregistering files, when seeing:

```
mktemp: too few X's in template ‘_stacklib_’
```