### PR TITLE
Add support for Git for Windows / MINGW users

### DIFF
--- a/bin/_blackbox_common.sh
+++ b/bin/_blackbox_common.sh
@@ -371,7 +371,7 @@ function md5sum_file() {
     Darwin )
       md5 -r "$1" | awk '{ print $1 }'
       ;;
-    Linux | CYGWIN*)
+    Linux | CYGWIN* | MINGW* )
       md5sum "$1" | awk '{ print $1 }'
       ;;
     * )
@@ -387,7 +387,7 @@ function cp_permissions() {
     Darwin )
       chmod $( stat -f '%p' "$1" ) "${@:2}"
       ;;
-    Linux | CYGWIN* )
+    Linux | CYGWIN* | MINGW* )
       chmod --reference "$1" "${@:2}"
       ;;
     * )

--- a/bin/_stack_lib.sh
+++ b/bin/_stack_lib.sh
@@ -57,7 +57,7 @@ function create_self_deleting_tempfile() {
       : "${TMPDIR:=/tmp}"
       filename=$(mktemp -t _stacklib_.XXXXXXXX )
       ;;
-    Linux | CYGWIN* )
+    Linux | CYGWIN* | MINGW* )
       filename=$(mktemp)
       ;;
     * )
@@ -78,7 +78,7 @@ function create_self_deleting_tempdir() {
       : "${TMPDIR:=/tmp}"
       filename=$(mktemp -d -t _stacklib_.XXXXXXXX )
       ;;
-    Linux | CYGWIN* )
+    Linux | CYGWIN* | MINGW* )
       filename=$(mktemp -d)
       ;;
     * )
@@ -102,7 +102,7 @@ function make_self_deleting_tempfile() {
       : "${TMPDIR:=/tmp}"
       name=$(mktemp -t _stacklib_.XXXXXXXX )
       ;;
-    Linux | CYGWIN* )
+    Linux | CYGWIN* | MINGW* )
       name=$(mktemp)
       ;;
     * )
@@ -124,7 +124,7 @@ function make_tempdir() {
       : "${TMPDIR:=/tmp}"
       name=$(mktemp -d -t _stacklib_.XXXXXXXX )
       ;;
-    Linux | CYGWIN* )
+    Linux | CYGWIN* | MINGW* )
       name=$(mktemp -d)
       ;;
     * )
@@ -164,7 +164,7 @@ function fail_if_in_root_directory() {
         exit 1
       fi
       ;;
-    Linux | CYGWIN* )
+    Linux | CYGWIN* | MINGW* )
       if [[ $(stat -c'%i' / ) == $(stat -c'%i' . ) ]] ; then
         echo 'SECURITY ALERT: The current directory is the root directory.'
         echo 'Exiting...'


### PR DESCRIPTION
If you install Git for Windows (https://git-for-windows.github.io/) you get a console
,either CMD or MINTTY, which returns MINGW* for uname -s. So if you run blackbox_addadmin
or the other commands, you'll get: "ERROR: Unknown OS. Exiting."

I've simply added MINGW* to the Linux and CYGWIN checks and it seems to work fine.

NOTE: I didn't touch tools/test_functions.sh allthough it should probably be updated as well.