### PR TITLE
remove unencrypted file from .gitignore when deregistering

### DIFF
--- a/bin/blackbox_deregister_file
+++ b/bin/blackbox_deregister_file
@@ -26,6 +26,7 @@ fail_if_not_exists "$encrypted_file" "Please specify an existing file."
 prepare_keychain
 remove_filename_from_cryptlist "$unencrypted_file"
 vcs_remove "$encrypted_file"
+vcs_notice "$unencrypted_file"
 vcs_add "$BB_FILES" 
 
 vcs_commit "Removing from blackbox: ${unencrypted_file}" "$BB_FILES" "$encrypted_file"


### PR DESCRIPTION
This is a fix for issue #127.