### PR TITLE
Make OUTPUTDIR overridable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 SHELL=/bin/sh
 
 PKGNAME=stack_blackbox
+BASEDIR?=~
+OUTPUTDIR?="$(BASEDIR)/debbuild-${PACKAGENAME}"
 
 all:
 	@echo 'Menu:'
@@ -30,14 +32,14 @@ packages-rpm-debug:
 	@echo BUILD:
 	@PKGRELEASE=99 make packages
 	@echo ITEMS TO BE PACKAGED:
-	find ~/rpmbuild-$(PKGNAME)/installroot -type f
+	find $(BASEDIR)/rpmbuild-$(PKGNAME)/installroot -type f
 	@echo ITEMS ACTUALLY IN PACKAGE:
-	@rpm -qpl $$(cat ~/rpmbuild-$(PKGNAME)/bin-packages.txt)
+	@rpm -qpl $$(cat $(BASEDIR)/rpmbuild-$(PKGNAME)/bin-packages.txt)
 
 local-rpm:
 	@PKGRELEASE=1 make packages
 	-@sudo rpm -e $(PKGNAME)
-	sudo rpm -i $$(cat ~/rpmbuild-$(PKGNAME)/bin-packages.txt)
+	sudo rpm -i $$(cat $(BASEDIR)/rpmbuild-$(PKGNAME)/bin-packages.txt)
 
 lock-rpm:
 	sudo yum versionlock add $(PKGNAME)
@@ -63,7 +65,7 @@ manual-uninstall:
 #
 
 packages-deb:	tools/mk_deb_fpmdir.stack_blackbox.txt
-	cd tools && PKGRELEASE="$${PKGRELEASE}" PKGDESCRIPTION="Safely store secrets in git/hg/svn repos using GPG encryption" ./mk_deb_fpmdir stack_blackbox mk_deb_fpmdir.stack_blackbox.txt
+	cd tools && OUTPUTDIR=$(OUTPUTDIR) PKGRELEASE="$${PKGRELEASE}" PKGDESCRIPTION="Safely store secrets in git/hg/svn repos using GPG encryption" ./mk_deb_fpmdir stack_blackbox mk_deb_fpmdir.stack_blackbox.txt
 
 # Make mk_deb_fpmdir.vcs_blackbox.txt from mk_rpm_fpmdir.stack_blackbox.txt:
 tools/mk_deb_fpmdir.stack_blackbox.txt: tools/mk_rpm_fpmdir.stack_blackbox.txt
@@ -75,12 +77,12 @@ packages-deb-debug:	tools/mk_deb_fpmdir.stack_blackbox.txt
 	@echo ITEMS TO BE PACKAGED:
 	find ~/debbuild-$(PKGNAME)/installroot -type f
 	@echo ITEMS ACTUALLY IN PACKAGE:
-	@dpkg --contents $$(cat ~/debbuild-$(PKGNAME)/bin-packages.txt)
+	@dpkg --contents $$(cat $(BASEDIR)/debbuild-$(PKGNAME)/bin-packages.txt)
 
 local-deb:
 	@PKGRELEASE=1 make packages
 	-@sudo dpkg -e $(PKGNAME)
-	sudo dpkg -i $$(cat ~/rpmbuild-$(PKGNAME)/bin-packages.txt)
+	sudo dpkg -i $$(cat $(BASEDIR)/rpmbuild-$(PKGNAME)/bin-packages.txt)
 
 #
 # MacPorts builds

--- a/tools/mk_deb_fpmdir
+++ b/tools/mk_deb_fpmdir
@@ -27,8 +27,14 @@ shift
 # If there is no epoch, assume 0
 : ${PKGEPOCH:=0}
 
-# The DEB is output here: (should be a place that can be wiped)
-OUTPUTDIR="${HOME}/debbuild-$PACKAGENAME"
+# Allow us to set a different OUTPUTDIR if we're building in CI/CD
+if [[ -z "${OUTPUTDIR}" ]]; then
+  # The DEB is output here: (should be a place that can be wiped)
+  OUTPUTDIR="${HOME}/debbuild-${PACKAGENAME}"
+else
+  echo "Using $OUTPUTDIR for OUTPUTDIR instead of ${HOME}/debbuild-${PACKAGENAME}"
+fi
+
 # The TeamCity templates expect to find the list of artifacts here:
 DEB_BIN_LIST="${OUTPUTDIR}/bin-packages.txt"
 
@@ -36,6 +42,7 @@ DEB_BIN_LIST="${OUTPUTDIR}/bin-packages.txt"
 
 # Clean the output dir.
 rm -rf "$OUTPUTDIR"
+
 mkdir -p "$OUTPUTDIR/installroot"
 
 # Copy the files into place:
@@ -51,7 +58,7 @@ cat """$@""" | while read -a arr ; do
   DST="$OUTPUTDIR/installroot/${arr[1]}"
   SRC="${arr[2]}"
   if [[ $SRC == "cmd/"* || $SRC == *"/cmd/"* ]]; then
-    ( cd $(dirname "$SRC" ) && go build -a -v ) 
+    ( cd $(dirname "$SRC" ) && go build -a -v )
   fi
   install -D -T -b -m "$PERM" -T "$SRC" "$DST"
 done

--- a/tools/mk_rpm_fpmdir
+++ b/tools/mk_rpm_fpmdir
@@ -27,8 +27,14 @@ shift
 # If there is no epoch, assume 0
 : ${PKGEPOCH:=0}
 
-# The RPM is output here: (should be a place that can be wiped)
-OUTPUTDIR="${HOME}/rpmbuild-$PACKAGENAME"
+# Allow us to set a different OUTPUTDIR if we're building in CI/CD
+if [[ -z "${OUTPUTDIR}" ]]; then
+  # The RPM is output here: (should be a place that can be wiped)
+  OUTPUTDIR="${HOME}/rpmbuild-${PACKAGENAME}"
+else
+  echo "Using $OUTPUTDIR for OUTPUTDIR instead of ${HOME}/rpmbuild-${PACKAGENAME}"
+fi
+
 # The TeamCity templates expect to find the list of artifacts here:
 RPM_BIN_LIST="${OUTPUTDIR}/bin-packages.txt"
 
@@ -51,7 +57,7 @@ cat """$@""" | while read -a arr ; do
   DST="$OUTPUTDIR/installroot/${arr[1]}"
   SRC="${arr[2]}"
   if [[ $SRC == "cmd/"* || $SRC == *"/cmd/"* ]]; then
-    ( cd $(dirname "$SRC" ) && go build -a -v ) 
+    ( cd $(dirname "$SRC" ) && go build -a -v )
   fi
   install -D -T -b -m "$PERM" -T "$SRC" "$DST"
 done


### PR DESCRIPTION
Users (like me on my Jenkins server) may not want to put output debs and rpms in ~.

Closes #137 