### PR TITLE
Warn user if there isn't a secure deletion utility

### DIFF
--- a/bin/_blackbox_common.sh
+++ b/bin/_blackbox_common.sh
@@ -273,6 +273,7 @@ function shred_file() {
     CMD=srm
     OPT=-f
   else
+    echo "shred_file: WARNING: No secure deletion utility (shred or srm) present; using insecure rm"
     CMD=rm
     OPT=-f
   fi


### PR DESCRIPTION
Otherwise, somebody with neither shred nor srm installed could blithely
go on using Blackbox assuming that their working copies are getting
securely deleted.