### PR TITLE
strip out any \r values hanging on the end of the destination filename

### DIFF
--- a/bin/blackbox_postdeploy
+++ b/bin/blackbox_postdeploy
@@ -28,6 +28,10 @@ prepare_keychain
 # Decrypt:
 echo '========== Decrypting new/changed files: START'
 while IFS= read <&99 -r unencrypted_file; do
+
+  #on windows the carriage return is kept in the file name so we
+  #need to strip it.
+  unencrypted_file=$(echo $unencrypted_file|tr -d '\r')
   encrypted_file=$(get_encrypted_filename "$unencrypted_file")
   decrypt_file_overwrite "$encrypted_file" "$unencrypted_file"
   cp_permissions "$encrypted_file" "$unencrypted_file"

--- a/bin/blackbox_postdeploy
+++ b/bin/blackbox_postdeploy
@@ -28,7 +28,6 @@ prepare_keychain
 # Decrypt:
 echo '========== Decrypting new/changed files: START'
 while IFS= read <&99 -r unencrypted_file; do
-
   #on windows the carriage return is kept in the file name so we
   #need to strip it.
   unencrypted_file=$(echo $unencrypted_file|tr -d '\r')


### PR DESCRIPTION
tldr; blackbox_postdeploy leaves carriage return at end of unencrypted file name on windows using MinGW

full story:

I'm using windows, mingw and have everything working with blackbox except for blackbox_postdeploy which works - but munges the decrypted file name.

Here is a contrived example.

Let's say I have the files, `secrets1.txt` and `secrets2.text` that I have encrypted using `blackbox_register_file`.  If I use `blackbox_edit secrets1.txt.gpg` the file written to disk is titled `secrets1.txt` as expected.  Perfect!

However, if I use `blackbox_postdeploy` I get a carriage return `\r` at the end of each file generated which doesn't work so well:

`secrets1.txt'$'\r`
`secrets2.txt'$'\r`

Interestingly, if I decrypt each file individually and then use `blackbox_shred_all_files` the file names are processed properly (the \r doesn't seem to manifest) and the correct files are deleted.  

If I use `blackbox_postdeploy`  and then `blackbox_shred_all_files` the shred fails to delete the files because it doesn't use the `\r` in the filename.

becuase this only happens in blackbox_postdeploy I only added the logic in there instead of creating a new function in _blackbox_common.sh
