### PR TITLE
remove MinGW dependecy on GpG4Win (gpg-agent) in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ Note: MinGW (comes with Git for Windows) support requires the following addition
 	-	[Git for Windows](https://git-scm.com/) (not tested with Mercurial)
 		-	Git Bash MINTTY returns a MinGW console.  So when you install make sure you pick `MINTTY` instead of windows console.  You'll be executing blackbox from the Git Bash prompt.
 		-	You need at least version 2.8.1 of Git for Windows.
-	-	[Gpg4Win](https://www.gpg4win.org/) with the path add to your PATH (ex: `PATH=%PATH%;C:\Program Files (x86)\GNU\GnuPG`)
 	-	[GnuWin32](https://sourceforge.net/projects/getgnuwin32/files/) - needed for various tools not least of which is mktemp which is used by blackbox
 		-	after downloading the install just provides you with some batch files.  Because of prior issues at sourceforge and to make sure you get the latest version of each package the batch files handle the brunt of the work of getting the correct packages and installing them for you.
 		-	from a **windows command prompt** run `download.bat`  once it has completed run `install.bat` then add the path for those tools to your PATH (ex: `PATH=%PATH%;c:\GnuWin32\bin`)


### PR DESCRIPTION
The gpg-agent that ships with GpG4Win is a version 2 gpg agent and only works with gpg2.  The gpg in MinGW is gpg 1.x and it doesn't pick up this gpg-agent.

However, everything still works - you just have to enter your password for each file you decrypt.  Slightly onerous but not a huge deal breaker.

I notice there is  away to specify your own gpg versoin in the _blackbox_common.sh file but I don't really know how that works.  If someone were to specify to use gpg2 then they could probably use the agent in Gpg4Win but I don't know and don't know how to test that.