### PR TITLE
Fixes for subversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Table of Contents
 - [Replace expired keys:](#replace-expired-keys)
 - [Some common errors:](#some-common-errors)
 - [Using Blackbox without a repo](#using-blackbox-without-a-repo)
+- [Some Subversion gotchas:](#some-subversion-gotchas)
 - [How to submit bugs or ask questions?](#how-to-submit-bugs-or-ask-questions)
 - [Developer Info](#developer-info)
 - [Alternatives](#alternatives)
@@ -635,6 +636,13 @@ The following commands have been tested outside a repo:
 -	`blackbox_postdeploy`
 -	`blackbox_edit_start`
 -	`blackbox_edit_end`
+
+Some Subversion gotchas:
+========================
+
+The current implementation will store the blackbox in `/keyrings` at the root of the entire repo.  this will create an issue between environments that have different roots (ie, checking out `/` on development vs `/releases/foo` in production).  To get around this, you can `export BLACKBOX_REPOBASE=/path/to/repo` and set a specific base for your repo.
+
+This was originally written for git and supports a two-phase commit, in which `commit` is a local commit and "push" sends the change upstream to the version control server when something is registered or deregistered with the system.  The current implementation will immediately `commit` a file (to the upstream subversion server) when you execute a `blackbox_*` command.
 
 How to submit bugs or ask questions?
 ====================================

--- a/bin/_blackbox_common.sh
+++ b/bin/_blackbox_common.sh
@@ -62,6 +62,11 @@ export REPOBASE=$(physical_directory_of "$REPOBASE")
 # FIXME: Verify this function by checking for .hg or .git
 # after determining what we believe to be the answer.
 
+if [[ -n "$BLACKBOX_REPOBASE" ]]; then
+	echo "Using custom repobase: $BLACKBOX_REPOBASE"
+	export REPOBASE="$BLACKBOX_REPOBASE"
+fi
+
 KEYRINGDIR="$REPOBASE/$BLACKBOXDATA"
 BB_ADMINS_FILE="blackbox-admins.txt"
 BB_ADMINS="${KEYRINGDIR}/${BB_ADMINS_FILE}"
@@ -567,7 +572,7 @@ function vcs_ignore_git() {
 }
 # Subversion
 function vcs_ignore_svn() {
-  svn propset svn:ignore "$(vcs_relative_path "$file")"
+  svn propset svn:ignore "$file" "$(vcs_relative_path)"
 }
 # Perforce
 function vcs_ignore_p4() {

--- a/bin/blackbox_initialize
+++ b/bin/blackbox_initialize
@@ -19,6 +19,11 @@ if [[ $1 != 'yes' ]]; then
   fi
 fi
 
+if [[ $VCS_TYPE = "unknown" ]]; then
+	echo 'Not in a known VCS directory'
+	exit 1
+fi
+
 change_to_vcs_root
 
 echo VCS_TYPE: $VCS_TYPE
@@ -30,11 +35,17 @@ vcs_add "${KEYRINGDIR}"
 touch "$BLACKBOXDATA/$BB_ADMINS_FILE" "$BLACKBOXDATA/$BB_FILES_FILE"
 vcs_add "$BLACKBOXDATA/$BB_ADMINS_FILE" "$BLACKBOXDATA/$BB_FILES_FILE"
 
-IGNOREFILE="$(vcs_ignore_file_path)"
-test -f "$IGNOREFILE" && vcs_add "$IGNOREFILE"
+if [[ $VCS_TYPE = "svn" ]]; then
+	echo
+	echo
+	echo '`subversion` automatically tracks the ignored files; you just need to commit.'
+else
+	IGNOREFILE="$(vcs_ignore_file_path)"
+	test -f "$IGNOREFILE" && vcs_add "$IGNOREFILE"
 
-# Make a suggestion:
-echo
-echo
-echo 'NEXT STEP: You need to manually check these in:'
-echo '     ' $VCS_TYPE commit -m\'INITIALIZE BLACKBOX\' keyrings "$IGNOREFILE"
+	# Make a suggestion:
+	echo
+	echo
+	echo 'NEXT STEP: You need to manually check these in:'
+	echo '     ' $VCS_TYPE commit -m\'INITIALIZE BLACKBOX\' keyrings "$IGNOREFILE"
+fi

--- a/bin/blackbox_register_new_file
+++ b/bin/blackbox_register_new_file
@@ -52,5 +52,9 @@ for target in "$@"; do
 done
 
 echo "========== UPDATING VCS: DONE"
-echo "Local repo updated.  Please push when ready."
-echo "    $VCS_TYPE push"
+if [[ $VCS_TYPE = "svn" ]]; then
+	echo "Local repo updated and file pushed to source control (unless an error was displayed)."
+else
+	echo "Local repo updated.  Please push when ready."
+	echo "    $VCS_TYPE push"
+fi


### PR DESCRIPTION
The current subversion support is broken.  This fix makes it a little less broken (but probably still broken)

Fixes
* the syntax for svn:ignore was corrected
* the messaging on initialize and register was fixed
* some docs were added as 'gotchas'
* also added a custom environment variable to override the default repository root.  this is needed on subversion.  by default blackbox uses "/REPO/keyrings" however a checkout is likely to be "/REPO/TAGS/version" -- which means it would not have "/REPO/keyrings".  While this could create issues with multiple keyrings in a repo, the same issue happens with git branches.

Still broken:
* The subversion integration calls `commit` immediately upon file manipulation, however `svn commit` is really analogous to `git push`.   blackbox should probably be silent on `commit` and instruct a manual commit like it does for push.  The reason for this recommendation is that the current approach will always generate errors when working offline.