### PR TITLE
added `blackbox_listadmins`, which just displays active admins via `c…

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Commands:
 | `blackbox_postdeploy`        | Decrypt all managed files (batch)                                       |
 | `blackbox_addadmin`          | Add someone to the list of people that can encrypt/decrypt secrets      |
 | `blackbox_removeadmin`       | Remove someone from the list of people that can encrypt/decrypt secrets |
+| `blackbox_listadmins`        | Display the list of people that can encrypt/decrypt secrets             |
 | `blackbox_shred_all_files`   | Safely delete any decrypted files                                       |
 | `blackbox_update_all_files`  | Decrypt then re-encrypt all files. Useful after keys are changed        |
 | `blackbox_whatsnew`          | show what has changed in the last commit for a given file               |

--- a/bin/blackbox_listadmins
+++ b/bin/blackbox_listadmins
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+#
+# blackbox_listadmins -- List active admins for keyring
+#
+
+# Example:
+#    blackbox_listadmins
+#
+
+set -e
+source "${0%/*}/_blackbox_common.sh"
+
+fail_if_not_in_repo
+
+
+# simply display the contents of the admins file
+cat "$BB_ADMINS"

--- a/tools/mk_deb_fpmdir.stack_blackbox.txt
+++ b/tools/mk_deb_fpmdir.stack_blackbox.txt
@@ -9,6 +9,7 @@ exec /usr/bin/blackbox_edit             ../bin/blackbox_edit
 exec /usr/bin/blackbox_edit_end         ../bin/blackbox_edit_end
 exec /usr/bin/blackbox_edit_start       ../bin/blackbox_edit_start
 exec /usr/bin/blackbox_initialize       ../bin/blackbox_initialize
+exec /usr/bin/blackbox_listadmins       ../bin/blackbox_listadmins
 exec /usr/bin/blackbox_list_files       ../bin/blackbox_list_files
 exec /usr/bin/blackbox_postdeploy       ../bin/blackbox_postdeploy
 exec /usr/bin/blackbox_register_new_file ../bin/blackbox_register_new_file

--- a/tools/mk_macports.vcs_blackbox.txt
+++ b/tools/mk_macports.vcs_blackbox.txt
@@ -9,6 +9,7 @@ exec bin/blackbox_edit             ../bin/blackbox_edit
 exec bin/blackbox_edit_end         ../bin/blackbox_edit_end
 exec bin/blackbox_edit_start       ../bin/blackbox_edit_start
 exec bin/blackbox_initialize       ../bin/blackbox_initialize
+exec bin/blackbox_listadmins       ../bin/blackbox_listadmins
 exec bin/blackbox_list_files       ../bin/blackbox_list_files
 exec bin/blackbox_postdeploy       ../bin/blackbox_postdeploy
 exec bin/blackbox_register_new_file ../bin/blackbox_register_new_file

--- a/tools/mk_rpm_fpmdir.stack_blackbox.txt
+++ b/tools/mk_rpm_fpmdir.stack_blackbox.txt
@@ -11,6 +11,7 @@ exec /usr/blackbox/bin/blackbox_edit             ../bin/blackbox_edit
 exec /usr/blackbox/bin/blackbox_edit_end         ../bin/blackbox_edit_end
 exec /usr/blackbox/bin/blackbox_edit_start       ../bin/blackbox_edit_start
 exec /usr/blackbox/bin/blackbox_initialize       ../bin/blackbox_initialize
+exec /usr/blackbox/bin/blackbox_listadmins       ../bin/blackbox_listadmins
 exec /usr/blackbox/bin/blackbox_list_files       ../bin/blackbox_list_files
 exec /usr/blackbox/bin/blackbox_postdeploy       ../bin/blackbox_postdeploy
 exec /usr/blackbox/bin/blackbox_register_new_file ../bin/blackbox_register_new_file


### PR DESCRIPTION
added `blackbox_listadmins`, which just displays active admins via `cat "$BB_ADMINS"`

This allows the current admins to be quickly listed from anywhere within a repo, instead of deriving the path to the repo's keyring file.

https://github.com/StackExchange/blackbox/issues/151