### PR TITLE
removing auto-commits from subversion and adding some docstrings

### DIFF
--- a/bin/_blackbox_common.sh
+++ b/bin/_blackbox_common.sh
@@ -502,7 +502,9 @@ function vcs_commit_git() {
 }
 # Subversion
 function vcs_commit_svn() {
-  svn commit -m "$@"
+  # svn commit -m "$@"
+  # subversion commits hit the upstream server; best to not commit
+  :
 }
 # Perforce
 function vcs_commit_p4() {

--- a/bin/blackbox_deregister_file
+++ b/bin/blackbox_deregister_file
@@ -29,7 +29,14 @@ vcs_remove "$encrypted_file"
 vcs_notice "$unencrypted_file"
 vcs_add "$BB_FILES" 
 
-vcs_commit "Removing from blackbox: ${unencrypted_file}" "$BB_FILES" "$encrypted_file"
-echo "========== UPDATING VCS: DONE"
-echo "Local repo updated.  Please push when ready."
-echo "    $VCS_TYPE push"
+if [[ $VCS_TYPE == "svn" ]]; then
+  echo "========== UPDATING VCS: DONE"
+  echo "Local repo updated."
+  echo "Please commit to subversion server when ready."
+  echo "    svn commit"
+else:
+  vcs_commit "Removing from blackbox: ${unencrypted_file}" "$BB_FILES" "$encrypted_file"
+  echo "========== UPDATING VCS: DONE"
+  echo "Local repo updated.  Please push when ready."
+  echo "    $VCS_TYPE push"
+fi

--- a/bin/blackbox_initialize
+++ b/bin/blackbox_initialize
@@ -35,17 +35,18 @@ vcs_add "${KEYRINGDIR}"
 touch "$BLACKBOXDATA/$BB_ADMINS_FILE" "$BLACKBOXDATA/$BB_FILES_FILE"
 vcs_add "$BLACKBOXDATA/$BB_ADMINS_FILE" "$BLACKBOXDATA/$BB_FILES_FILE"
 
-if [[ $VCS_TYPE = "svn" ]]; then
-	echo
-	echo
+# Make a suggestion:
+# some whitespace
+echo
+echo
+if [[ $VCS_TYPE == "svn" ]]; then
 	echo '`subversion` automatically tracks the ignored files; you just need to commit.'
+	echo 'NEXT STEP: You need to manually check these in:'
+	echo '     ' svn commit -m\'INITIALIZE BLACKBOX\' keyrings
 else
 	IGNOREFILE="$(vcs_ignore_file_path)"
 	test -f "$IGNOREFILE" && vcs_add "$IGNOREFILE"
 
-	# Make a suggestion:
-	echo
-	echo
 	echo 'NEXT STEP: You need to manually check these in:'
 	echo '     ' $VCS_TYPE commit -m\'INITIALIZE BLACKBOX\' keyrings "$IGNOREFILE"
 fi

--- a/bin/blackbox_register_new_file
+++ b/bin/blackbox_register_new_file
@@ -44,7 +44,11 @@ function register_new_file() {
   vcs_ignore "$unencrypted_file"
   echo 'NOTE: "already tracked!" messages are safe to ignore.'
   vcs_add "$BB_FILES" "$encrypted_file"
-  vcs_commit "registered in blackbox: ${unencrypted_file}" "$BB_FILES" "$encrypted_file"
+  if [[ $VCS_TYPE == "svn" ]]; then
+  	echo "registered in blackbox: ${unencrypted_file} as ${encrypted_file}; you must commit to subversion repo."
+  else
+	vcs_commit "registered in blackbox: ${unencrypted_file}" "$BB_FILES" "$encrypted_file"
+  fi
 }
 
 for target in "$@"; do
@@ -52,9 +56,9 @@ for target in "$@"; do
 done
 
 echo "========== UPDATING VCS: DONE"
-if [[ $VCS_TYPE = "svn" ]]; then
-	echo "Local repo updated and file pushed to source control (unless an error was displayed)."
+echo "Local repo updated.  Please push when ready."
+if [[ $VCS_TYPE == "svn" ]]; then
+	echo "    svn commit"
 else
-	echo "Local repo updated.  Please push when ready."
 	echo "    $VCS_TYPE push"
 fi

--- a/bin/blackbox_update_all_files
+++ b/bin/blackbox_update_all_files
@@ -53,12 +53,20 @@ done 99<"$BB_FILES"
 
 fail_if_keychain_has_secrets
 
-echo '========== COMMITING TO VCS:'
+echo '========== ADDING TO VCS:'
 while IFS= read <&99 -r unencrypted_file; do
     vcs_add "$unencrypted_file.gpg"
 done 99<"$BB_FILES"
-vcs_commit 'Re-encrypted keys'
+
+if [[ $VCS_TYPE != "svn" ]]; then
+	echo '========== COMITTING TO VCS:'
+	vcs_commit 'Re-encrypted keys'
+fi
 
 echo '========== DONE.'
 echo 'Likely next step:'
-echo "    $VCS_TYPE push"
+if [[ $VCS_TYPE == "svn" ]]; then
+	echo "    svn commit"
+else
+	echo "    $VCS_TYPE push"
+fi


### PR DESCRIPTION
First off- this seems to work on subversion and git but DEFINITELY needs a review by others.

There is one broken element that I don't know how to address.  

In `blackbox_deregister_file` https://github.com/jvanasco/blackbox/blob/9e232bd1a115824e3adb2348e330eed8e82890bd/bin/blackbox_deregister_file#L28

it is possible that line 28 `vcs_remove "$encrypted_file"` will fail under 2 circumstances because subversion wants a `--force` argument
- scenario 1: blackbox has added the file to it's tracked files, and subversion has marked it for ADD, but has not committed yet.
- scenario 2: the file was altered (ie, re-encrypted with a new key) before a deletion is requested

When that happens, the shell script exits with the subversion error message.

I don't know enough shell scripting to catch that and notify the user.
