### PR TITLE
Use PKGNAME variable defined above.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL=/bin/sh
 
 PKGNAME=stack_blackbox
 BASEDIR?=~
-OUTPUTDIR?="$(BASEDIR)/debbuild-${PACKAGENAME}"
+OUTPUTDIR?="$(BASEDIR)/debbuild-${PKGNAME}"
 
 all:
 	@echo 'Menu:'

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL=/bin/sh
 
 PKGNAME=stack_blackbox
-BASEDIR?=~
+BASEDIR?=$(HOME)
 OUTPUTDIR?="$(BASEDIR)/debbuild-${PKGNAME}"
 
 all:


### PR DESCRIPTION
It looks like the PACKAGENAME variable have been renamed PKGNAME but that this one line has been missed. Right now it's referencing an nonexistent variable.

The tilde doesn't get expanded when in between quotes, and I suspect the quotes have been added to prevent failures with "funny" directory names (spaces etc..). The tilde is expanded by the shell, so wherever it will work $HOME should work too, but will actually expand properly.