### PR TITLE
#162: Added instructions to make "git diff" work

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,6 +616,23 @@ Any files that were temporarily copied in the first step so as to not be overwri
 
 (Thanks to @chishaku for finding a solution to this problem!)
 
+### Configure git to show diffs in encrypted files
+
+It's possible to tell Git to decrypt versions of the file before running them through `git diff` or `git log`. To achieve this do:
+
+- Add the following to `.gitattributes` at the top of the git repository:
+```
+*.gpg diff=blackbox
+```
+
+- Add the following to `.git/config`:
+```
+[diff "blackbox"]
+    textconv = gpg --use-agent -q --batch --decrypt
+````
+
+And now commands like `git log -p file.gpg` will show a nice log of the changes in the encrypted file.
+
 Some common errors:
 ===================
 


### PR DESCRIPTION
Added a paragraph about configuring `git` to decrypt files for diff/log