### PR TITLE
ignore backup files and secring.gpg in $BLACKBOXDATA

### DIFF
--- a/bin/blackbox_initialize
+++ b/bin/blackbox_initialize
@@ -27,7 +27,7 @@ fi
 change_to_vcs_root
 
 echo VCS_TYPE: $VCS_TYPE
-vcs_ignore keyrings/live/pubring.gpg~ keyrings/live/pubring.kbx~ keyrings/live/secring.gpg
+vcs_ignore "${BLACKBOXDATA}/pubring.gpg~" "${BLACKBOXDATA}/pubring.kbx~" "${BLACKBOXDATA}/secring.gpg"
 
 # Make directories
 mkdir -p "${KEYRINGDIR}"


### PR DESCRIPTION
#### What this pull addresses

Currently the default `keyrings/live` directory is hardcoded in `blackbox_initialize` in the call to `vcs_ignore`. This allows users to easily check the secring.gpg file into source control if they set a different $BLACKBOXDATA :grin:.

For example,

```
$ BLACKBOXDATA=foo/bar blackbox_initialize
```

will create

```
.
|
|
foo
  |—bar
    |—blackbox-admins.txt
    |—blackbox-files.txt
```

but add the following lines to .gitignore (and all other vcs' ignore files).

```
/keyrings/live/pubring.gpg~
/keyrings/live/pubring.kbx~
/keyrings/live/secring.gpg
```

#### What this pull does

In the case of `$ BLACKBOXDATA=foo/bar blackbox_initialize`, this pull makes the ignore files get the following instead.

```
/foo/bar/pubring.gpg~
/foo/bar/pubring.kbx~
/foo/bar/secring.gpg
```