### PR TITLE
Remove the key from the keyring when removing an admin

### DIFF
--- a/bin/blackbox_removeadmin
+++ b/bin/blackbox_removeadmin
@@ -20,8 +20,15 @@ KEYNAME="$1"
 # Remove the email address from the BB_ADMINS file.
 remove_line "$BB_ADMINS" "$KEYNAME"
 
+
+# remove the admin key from the pubring
+$GPG --no-permission-warning --homedir="$KEYRINGDIR" --delete-key "$KEYNAME"
+pubring_path=$(get_pubring_path)
+vcs_add "$pubring_path" "$KEYRINGDIR/trustdb.gpg" "$BB_ADMINS"
+
+
 # Make a suggestion:
 echo
 echo
 echo 'NEXT STEP: Check these into the repo.  Probably with a command like...'
-echo $VCS_TYPE commit -m\'REMOVED ADMIN: $KEYNAME\' "$BLACKBOXDATA/$BB_ADMINS_FILE"
+echo $VCS_TYPE commit -m\'REMOVED ADMIN: $KEYNAME\' "$BLACKBOXDATA/trustdb.gpg" "$BLACKBOXDATA/$BB_ADMINS_FILE"


### PR DESCRIPTION
Currently when we remove an admin we don't remove its key from the pubring.
So when your key expires and you recreate a new one, blackbox_update_all_files will reimport your old key in the local keyring which is a bit annoying.
Plus, if someone removes an admin and forget to re-encrypt all the files, the admin still have full rights on the repo just by adding himself to the blackbox-admin.txt file.

This pr removes the key related to the user from the pubring.

The way it is done right now, it will ask you if you want to remove the key from the keyring (with the standard gpg on linux). We can plan to change that in the future if you want to avoid asking the question.