### PR TITLE
Requiring a file to be entered to finish editing

### DIFF
--- a/bin/blackbox_edit_end
+++ b/bin/blackbox_edit_end
@@ -9,6 +9,11 @@ source "${0%/*}/_blackbox_common.sh"
 
 next_steps=()
 
+if [ $# -eq 0 ]; then
+  echo >&2 "Please provide at least one file for which editing has finished"
+  exit 1
+fi
+
 for param in "$@" ; do
 
   unencrypted_file=$(get_unencrypted_filename "$param")

--- a/bin/blackbox_edit_start
+++ b/bin/blackbox_edit_start
@@ -7,6 +7,11 @@
 set -e
 source "${0%/*}/_blackbox_common.sh"
 
+if [ $# -eq 0 ]; then
+  echo >&2 "Please provide at least one file to start editing"
+  exit 1
+fi
+
 for param in "$@" ; do
 
   unencrypted_file=$(get_unencrypted_filename "$param")


### PR DESCRIPTION
Running `blackbox_edit_end` without an argument doesn't currently print out a warning that no files are being changed. A developer in my team who was new to Blackbox committed a decrypted file (and made no changes to the GPG file) as they didn't realise the command hadn't worked.

The check I've added should help to avoid these errors. I also added it to `blackbox_edit_start` for consistency.