### PR TITLE
Use the `rm` command with `-P` as a shred fallback

### DIFF
--- a/bin/_blackbox_common.sh
+++ b/bin/_blackbox_common.sh
@@ -277,6 +277,9 @@ function shred_file() {
     #NOTE: srm by default uses 35-pass Gutmann algorithm
     CMD=srm
     OPT=-f
+  elif _F=$(mktemp); rm -P $_F >/dev/null 2>/dev/null ; then
+    CMD=rm
+    OPT=-Pf
   else
     echo "shred_file: WARNING: No secure deletion utility (shred or srm) present; using insecure rm"
     CMD=rm


### PR DESCRIPTION
The newer versions of OSX (Sierra) have neither `shred` nor `srm`. They do have `rm` with the `-P` option, so we can fall back to that before resorting to plain old `rm`.