### PR TITLE
Fixing issue when Blackbox is used in a directory that sits at the file-system root.

### DIFF
--- a/bin/_blackbox_common.sh
+++ b/bin/_blackbox_common.sh
@@ -28,7 +28,7 @@ source "${0%/*}"/_stack_lib.sh
 function physical_directory_of() {
   local d=$(dirname "$1")
   local f=$(basename "$1")
-  (cd "$d" && echo "$(pwd -P)/$f" )
+  (cd "$d" && echo "$(pwd -P | sed 's/\/$//')/$f" )
 }
 
 # Set REPOBASE to the top of the repository


### PR DESCRIPTION
It appears that Blackbox doesn't work in directories that sit at the root of the file-system.

Steps to re-produce:

1. `mkdir /blackbox-sandbox && cd /blackbox-sandbox`
2. `git init`
3. `blackbox_initialize`
4. `blackbox_addadmin <admin>`
5. `echo 'my dirty little secret' > secrets.txt`
6. `blackbox_register_new_file secrets.txt`
7. `blackbox_decrypt_all_files`

Yields:

```
gpg: can't open 'blackbox-sandbox/secrets.txt.gpg': No such file or directory
gpg: decrypt_message failed: No such file or directory
```
Accordingly `blackbox_list_files` shows `blackbox-sandbox/secrets.txt`, which is incorrect.

I believe this change fixes the problem, and I'd be happy to add a test if you think it would be appropriate.