### PR TITLE
Silence 'not changed' output during keychain import

### DIFF
--- a/bin/_blackbox_common.sh
+++ b/bin/_blackbox_common.sh
@@ -172,7 +172,7 @@ function prepare_keychain() {
   make_self_deleting_tempfile keyringasc
   export LANG="C.UTF-8"
   $GPG --export --keyring "$(get_pubring_path)" >"$keyringasc"
-  $GPG --import "$keyringasc"
+  $GPG --import "$keyringasc" 2>&1 | egrep -v 'not changed$' >&2
   echo '========== Importing keychain: DONE' >&2
 }
 


### PR DESCRIPTION
Previously the keychain import appears to have redirected stderr to stdout,
silenced lines that indicate a key has 'not changed' then send the output back
to stdout.  This behaviour has been carried over to the new GnuPG-2.1
compatible implementation.