### PR TITLE
Clean up stdout when using BLACKBOX_REPOBASE

### DIFF
--- a/bin/_blackbox_common.sh
+++ b/bin/_blackbox_common.sh
@@ -63,7 +63,7 @@ export REPOBASE=$(physical_directory_of "$REPOBASE")
 # after determining what we believe to be the answer.
 
 if [[ -n "$BLACKBOX_REPOBASE" ]]; then
-	echo "Using custom repobase: $BLACKBOX_REPOBASE"
+	echo "Using custom repobase: $BLACKBOX_REPOBASE" >&2
 	export REPOBASE="$BLACKBOX_REPOBASE"
 fi
 


### PR DESCRIPTION
Currently, when `BLACKBOX_REPOBASE` is set, a message is echoed to stdout. This is undesirable in the use of `blackbox_cat`. This PR redirects the echo to stderr, which is the behavior of most other messages during decryption actions.