### PR TITLE
Don't explicitly pass files to vcs

### DIFF
--- a/bin/blackbox_register_new_file
+++ b/bin/blackbox_register_new_file
@@ -44,7 +44,7 @@ function register_new_file() {
   vcs_ignore "$unencrypted_file"
   echo 'NOTE: "already tracked!" messages are safe to ignore.'
   vcs_add "$BB_FILES" "$encrypted_file"
-  vcs_commit "registered in blackbox: ${unencrypted_file}" "$BB_FILES" "$encrypted_file"
+  vcs_commit "registered in blackbox: ${unencrypted_file}"
 }
 
 for target in "$@"; do


### PR DESCRIPTION
These files are already added to vcs so passing them to commit is redundant. If one of the other vcs systems requires this the ignore file should be added so that it's included in the commit.