### PR TITLE
Support Alpine Linux flavour of chmod

### DIFF
--- a/bin/_blackbox_common.sh
+++ b/bin/_blackbox_common.sh
@@ -408,8 +408,12 @@ function cp_permissions() {
       chmod $( stat -f '%p' "$1" | sed -e "s/^100//" ) "${@:2}"
       ;;
     Linux | CYGWIN* | MINGW* )
-      chmod --reference "$1" "${@:2}"
-      ;;
+      if [[ -e /etc/alpine-release ]]; then
+        chmod $( stat -c '%a' "$1" ) "${@:2}"
+      else
+        chmod --reference "$1" "${@:2}"
+      fi
+      ;; 
     * )
       echo 'ERROR: Unknown OS. Exiting. (cp_permissions)'
       exit 1


### PR DESCRIPTION
When decrypting secrets, file permissions are restored using `chmod` and
Alpine has a different set of arguments than other Linuxes; this change
tests for Alpine by looking for /etc/alpine-version and then uses `stat`
with the Alpine specific arguments to feed into `chmod`.