### PR TITLE
Run the tests on a CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,24 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: ubuntu:16.04
+    steps:
+      - checkout
+      - run:
+          name: 'Installing'
+          command: |
+            apt-get update -y
+            apt-get install -y build-essential expect git gnupg2 psmisc pinentry-tty rpm ruby-dev
+            gem install fpm
+      - run:
+          name: 'Cleaning'
+          command: |
+            rm -rf ~/.gpnupg
+            make clean
+      - run:
+          name: 'Testing'
+          command: |
+            GPG=gpg2 make test
+            make packages-deb
+            make packages-rpm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           name: 'Installing'
           command: |
             apt-get update -y
-            apt-get install -y build-essential expect git gnupg2 pinentry-tty psmisc rpm ruby-dev
+            apt-get install -y build-essential expect git gnupg2 pinentry-tty procps rpm ruby-dev
             gem install fpm
       - run:
           name: 'Cleaning'
@@ -41,7 +41,7 @@ jobs:
           name: 'Installing'
           command: |
             apt-get update -y
-            apt-get install -y build-essential expect git gnupg2 pinentry-tty psmisc rpm ruby-dev
+            apt-get install -y build-essential expect git gnupg2 pinentry-tty procps rpm ruby-dev
             gem install fpm
       - run:
           name: 'Cleaning'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,38 @@
 version: 2
+
+workflows:
+  version: 2
+  ci:
+    jobs:
+      - debian
+      - ubuntu
+
 jobs:
-  build:
+
+  debian:
+    docker:
+      - image: debian:9.1
+    steps:
+      - checkout
+      - run:
+          name: 'Installing'
+          command: |
+            apt-get update -y
+            apt-get install -y build-essential expect git gnupg2 pinentry-tty psmisc rpm ruby-dev
+            gem install fpm
+      - run:
+          name: 'Cleaning'
+          command: |
+            rm -rf ~/.gpnupg
+            make clean
+      - run:
+          name: 'Testing'
+          command: |
+            GPG=gpg2 make test
+            make packages-deb
+            make packages-rpm
+
+  ubuntu:
     docker:
       - image: ubuntu:16.04
     steps:
@@ -9,7 +41,7 @@ jobs:
           name: 'Installing'
           command: |
             apt-get update -y
-            apt-get install -y build-essential expect git gnupg2 psmisc pinentry-tty rpm ruby-dev
+            apt-get install -y build-essential expect git gnupg2 pinentry-tty psmisc rpm ruby-dev
             gem install fpm
       - run:
           name: 'Cleaning'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-BlackBox
+BlackBox ![CircleCI](https://circleci.com/gh/StackExchange/blackbox.svg?style=shield)
 ========
 
 Safely store secrets in a VCS repo (i.e. Git, Mercurial, Subversion or Perforce). These commands make it easy for you to Gnu Privacy Guard (GPG) encrypt specific files in a repo so they are "encrypted at rest" in your repository. However, the scripts make it easy to decrypt them when you need to view or edit them, and decrypt them for use in production. Originally written for Puppet, BlackBox now works with any Git or Mercurial repository.

--- a/tools/confidence_test.sh
+++ b/tools/confidence_test.sh
@@ -225,7 +225,7 @@ become_bob
 # This users's default group:
 DEFAULT_GID_NUM=$(id -g)
 # Pick a group that is not the default group:
-TEST_GID_NUM=$(id -G | fmt -1 | sort -rn | grep -xv "$(id -u)" | grep -xv "$(id -g)" | head -1)
+TEST_GID_NUM=$(grep -v "$DEFAULT_GID_NUM" /etc/group | cut -d: -f3 | sort -rn | head -1)
 echo "DEFAULT_GID_NUM=$DEFAULT_GID_NUM"
 echo "TEST_GID_NUM=$TEST_GID_NUM"
 


### PR DESCRIPTION
This PR brings a CI to blackbox.

I initially tried to run the tests on Travis, but it only supports [Ubuntu 12 and 14](https://docs.travis-ci.com/user/reference/overview/#Virtualization-environments). The tests require `pinentry-tty` which is not available on those versions. That's why I headed to CircleCI, which allows to run arbitrary Docker images (in this case the latest stable version of Debian and Ubuntu).

The tests [are passing](https://circleci.com/gh/aymericbeaumet/workflows/blackbox) for the fork, and [are ready to pass](https://circleci.com/gh/StackExchange/workflows/blackbox) for this repository as soon as this PR is merged. I also added a badge to the readme.

Closes https://github.com/StackExchange/blackbox/issues/186