### PR TITLE
Exclude our default keyring from import

### DIFF
--- a/bin/_blackbox_common.sh
+++ b/bin/_blackbox_common.sh
@@ -184,7 +184,7 @@ function prepare_keychain() {
   # NB: We must export the keys to a format that can be imported.
   make_self_deleting_tempfile keyringasc
   export LANG="C.UTF-8"
-  $GPG --export --keyring "$(get_pubring_path)" >"$keyringasc"
+  $GPG --export --no-default-keyring --keyring "$(get_pubring_path)" >"$keyringasc"
   $GPG --import "$keyringasc" 2>&1 | egrep -v 'not changed$' >&2
   echo '========== Importing keychain: DONE' >&2
 }


### PR DESCRIPTION
By default GPG will continue to perform actions against our default keyring.

During the keychain import stage this results in the export of both the
keyring for the repository we're working on, plus our own default keyring.
The import phase then continues to import all these exported keys, which
include the entries from our default keyring, for which all those entries
already exist.  If you have a lot of keys in your default keyring this takes a
long time, and can be noisy due to validation, yet offers absolutely no value.

To avoid all this overhead we only need to pass the `--no-default-keyring`
option to GPG during this export phase.  The result will still be what we're
expecting - i.e. that all entries from the repository pubring are imported
into our default keyring.