### PR TITLE
Fix problems when gpg2 is installed next to gpg

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Table of Contents
 - [Using BlackBox on Windows](#using-blackbox-on-windows)
 - [Using BlackBox without a repo](#using-blackbox-without-a-repo)
 - [Some Subversion gotchas](#some-subversion-gotchas)
-- [Using Blackbox when gpg2 is installed next to gpg](#using-Blackbox-when-gpg2-is-installed-next-to-gpg)
+- [Using Blackbox when gpg2 is installed next to gpg](#using-blackbox-when-gpg2-is-installed-next-to-gpg)
 - [How to submit bugs or ask questions?](#how-to-submit-bugs-or-ask-questions)
 - [Developer Info](#developer-info)
 - [Alternatives](#alternatives)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Table of Contents
 - [Using BlackBox on Windows](#using-blackbox-on-windows)
 - [Using BlackBox without a repo](#using-blackbox-without-a-repo)
 - [Some Subversion gotchas](#some-subversion-gotchas)
+- [Using Blackbox when gpg2 is installed next to gpg](#using-Blackbox-when-gpg2-is-installed-next-to-gpg)
 - [How to submit bugs or ask questions?](#how-to-submit-bugs-or-ask-questions)
 - [Developer Info](#developer-info)
 - [Alternatives](#alternatives)
@@ -703,6 +704,19 @@ Some Subversion gotchas
 The current implementation will store the blackbox in `/keyrings` at the root of the entire repo.  this will create an issue between environments that have different roots (ie, checking out `/` on development vs `/releases/foo` in production).  To get around this, you can `export BLACKBOX_REPOBASE=/path/to/repo` and set a specific base for your repo.
 
 This was originally written for git and supports a two-phase commit, in which `commit` is a local commit and "push" sends the change upstream to the version control server when something is registered or deregistered with the system.  The current implementation will immediately `commit` a file (to the upstream subversion server) when you execute a `blackbox_*` command.
+
+Using Blackbox when gpg2 is installed next to gpg
+=================================================
+
+In some situations, team members or automated roles need to install gpg
+2.x next to the system gpg version 1.x. to catch up with the teams gpg
+version. On Ubuntu 16. you can ```apt-get install gnupg2``` which
+installes the binary gpg2. If you want to use this gpg2 binany run every
+blackbox command with GPG=gpg2. E.g.:
+
+```
+GPG=gpg2 blackbox_postdeploy
+```
 
 How to submit bugs or ask questions?
 ====================================

--- a/bin/_blackbox_common.sh
+++ b/bin/_blackbox_common.sh
@@ -26,7 +26,7 @@ BLACKBOXDATA_CANDIDATES=(
 : "${EDITOR:=vi}" ;
 
 # Allow overriding gpg command
-: "${GPG:=gpg}" ;
+: "${GPG:=gpg2}" ;
 
 function physical_directory_of() {
   local d=$(dirname "$1")
@@ -184,8 +184,9 @@ function prepare_keychain() {
   # NB: We must export the keys to a format that can be imported.
   make_self_deleting_tempfile keyringasc
   export LANG="C.UTF-8"
-  $GPG --export --no-default-keyring --keyring "$(get_pubring_path)" >"$keyringasc"
-  $GPG --import "$keyringasc" 2>&1 | egrep -v 'not changed$' >&2
+  $GPG --keyring "$(get_pubring_path)" --export | $GPG --import
+  #$GPG --export --no-default-keyring --keyring "$(get_pubring_path)" >"$keyringasc"
+  #$GPG --import "$keyringasc" 2>&1 | egrep -v 'not changed$' >&2
   echo '========== Importing keychain: DONE' >&2
 }
 

--- a/bin/_blackbox_common.sh
+++ b/bin/_blackbox_common.sh
@@ -26,7 +26,7 @@ BLACKBOXDATA_CANDIDATES=(
 : "${EDITOR:=vi}" ;
 
 # Allow overriding gpg command
-: "${GPG:=gpg2}" ;
+: "${GPG:=gpg}" ;
 
 function physical_directory_of() {
   local d=$(dirname "$1")
@@ -184,9 +184,15 @@ function prepare_keychain() {
   # NB: We must export the keys to a format that can be imported.
   make_self_deleting_tempfile keyringasc
   export LANG="C.UTF-8"
-  $GPG --keyring "$(get_pubring_path)" --export | $GPG --import
-  #$GPG --export --no-default-keyring --keyring "$(get_pubring_path)" >"$keyringasc"
-  #$GPG --import "$keyringasc" 2>&1 | egrep -v 'not changed$' >&2
+
+  #if gpg2 is installed next to gpg like on ubuntu 16
+  if [[ "$GPG" != "gpg2" ]]; then
+    $GPG --export --no-default-keyring --keyring "$(get_pubring_path)" >"$keyringasc"
+    $GPG --import "$keyringasc" 2>&1 | egrep -v 'not changed$' >&2
+  else
+    $GPG --keyring "$(get_pubring_path)" --export | $GPG --import
+  fi
+
   echo '========== Importing keychain: DONE' >&2
 }
 


### PR DESCRIPTION
I encountered problems on a ubuntu 16 machine where I had to install gnupg2 to be able to use the blackbox setup made on my desktop. I implemented a slightly more sophisticated fix of the one I found in a comment in https://stackoverflow.com/questions/44247308/blackbox-gpg-decrypt-fails-dont-know-ctb-00 

I also instructions how to use gpg2 in the README. 

Related issues #184, #196, #221