### PR TITLE
Suggest committing changes to pubring.gpg when running blackbox_removeadmin

### DIFF
--- a/bin/blackbox_removeadmin
+++ b/bin/blackbox_removeadmin
@@ -31,4 +31,4 @@ vcs_add "$pubring_path" "$KEYRINGDIR/trustdb.gpg" "$BB_ADMINS"
 echo
 echo
 echo 'NEXT STEP: Check these into the repo.  Probably with a command like...'
-echo $VCS_TYPE commit -m\'REMOVED ADMIN: $KEYNAME\' "$BLACKBOXDATA/trustdb.gpg" "$BLACKBOXDATA/$BB_ADMINS_FILE"
+echo $VCS_TYPE commit -m\'REMOVED ADMIN: $KEYNAME\' "$BLACKBOXDATA/$(basename ${pubring_path})" "$BLACKBOXDATA/trustdb.gpg" "$BLACKBOXDATA/$BB_ADMINS_FILE"


### PR DESCRIPTION
This relates to https://github.com/StackExchange/blackbox/issues/247 where it has been observed that the blackbox_removeadmin script prompts the user to run an incorrect command after running blackbox_removeadmin. This commit simply adds pubring.gpg to the list of files to be committed.