### PR TITLE
Restore `make manual-install` with warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,13 @@ symlinks-install:
 	@cd bin && for f in `find . -type f -iname "*" ! -iname "Makefile"`; do ln -fs `pwd`/$$f /usr/local/bin/$$f; done
 	@echo 'Done.'
 
+manual-install:
+	@echo '***************************************************************'
+	@echo '*                      DEPRECATED                             *'
+	@echo '* `make manual-install` is now called `make symlinks-install` *'
+	@echo '***************************************************************'
+	$(MAKE) symlinks-install
+
 copy-install:
 	@echo 'Copying files from ./bin to /usr/local/bin'
 	@cd bin && for f in `find . -type f -iname "*" ! -iname "Makefile"`; do cp `pwd`/$$f /usr/local/bin/$$f; done


### PR DESCRIPTION
Today, when `stable` was released, many of our builds broke. It was very common for this kind of syntax in Dockerfiles.

```Dockerfile
# install blackbox
ADD https://github.com/StackExchange/blackbox/archive/stable.zip /tmp/blackbox.zip
RUN ls /usr/local/blackbox-stable || (cd /tmp && unzip blackbox.zip && mv blackbox-stable /usr/local && cd /usr/local/blackbox-stable && make manual-install && rm /tmp/blackbox.zip)
```

The removal of this make target in #244 caused a lot of problems for us and we had to scramble to get this updated in all of our services that use Blackbox.

This PR introduces an alias target with a large deprecation warning for others who rely on this `make` command in code.

<img width="643" alt="screen shot 2018-06-15 at 16 28 24" src="https://user-images.githubusercontent.com/630449/41491923-285aa550-70b9-11e8-89ae-08bc0b39ccaf.png">

I would also suggest that you consider releasing this as a bugfix on `stable` to help restore this behavior for others.