### PR TITLE
Add blackbox_less.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Commands
 | `blackbox_edit_start <file>`        | Decrypt a file so it can be updated                                     |
 | `blackbox_edit_end <file>`          | Encrypt a file after blackbox_edit_start was used                       |
 | `blackbox_cat <file>`               | Decrypt and view the contents of a file                                 |
+| `blackbox_less <file>`              | Decrypt and view the contents of a file via less                        |
 | `blackbox_diff`                     | Diff decrypted files against their original crypted version             |
 | `blackbox_initialize`               | Enable blackbox for a GIT or HG repo                                    |
 | `blackbox_register_new_file <file>` | Encrypt a file for the first time                                       |

--- a/bin/blackbox_less
+++ b/bin/blackbox_less
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+#
+# blackbox_less -- Decrypt a file, less it, shred it
+#
+set -e
+source "${0%/*}/_blackbox_common.sh"
+
+for param in "$@" ; do
+  shreddable=0
+  unencrypted_file=$(get_unencrypted_filename "$param")
+  if [[ ! -e "$unencrypted_file" ]]; then
+    "${BLACKBOX_HOME}/blackbox_edit_start" "$param"
+    shreddable=1
+  fi
+  less "$unencrypted_file"
+  if [[ $shreddable = 1 ]]; then
+    shred_file "$unencrypted_file"
+  fi
+done


### PR DESCRIPTION
Hi!

I have added blackbox_less to the toolset, basically it is the same as blackbox_cat, but it uses less instead of cat. This way you can view and search in long encrypted files without the need of piping blackbox_cat to less and without the possibility to modify it accidentally.