### PR TITLE
Global: Change "/bin/[x]" to "/usr/bin/env [x]"

### DIFF
--- a/bin/_blackbox_common.sh
+++ b/bin/_blackbox_common.sh
@@ -140,7 +140,7 @@ function fail_if_not_on_cryptlist() {
 
   if ! is_on_cryptlist "$name" ; then
     echo "ERROR: $name not found in $BB_FILES" >&2
-    echo "PWD=$(/bin/pwd)" >&2
+    echo "PWD=$(/usr/bin/env pwd)" >&2
     echo 'Exiting...' >&2
     exit 1
   fi

--- a/blackbox.plugin.zsh
+++ b/blackbox.plugin.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 # The MIT License (MIT)
 
 # Copyright (c) 2014 Stack Exchange, Inc.

--- a/tools/profile.d-usrblackbox-test.sh
+++ b/tools/profile.d-usrblackbox-test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # Test profile.d-usrblackbox.sh
 

--- a/tools/test_functions.sh
+++ b/tools/test_functions.sh
@@ -47,7 +47,7 @@ function assert_file_missing() {
 function assert_file_exists() {
   if [[ ! -e "$1" ]]; then
     echo "ASSERT FAILED: ${1} should exist."
-    echo "PWD=$(/bin/pwd -P)"
+    echo "PWD=$(/usr/bin/env pwd -P)"
     #echo "LS START"
     #ls -la
     #echo "LS END"


### PR DESCRIPTION
fixing an issue in NixOS where `_blackbox_common.sh` would try to access a non-existing `/bin/pwd`