### PR TITLE
Add blackbox_decrypt_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Commands
 | `blackbox_deregister_file <file>`   | Remove a file from blackbox                                             |
 | `blackbox_list_files`               | List the files maintained by blackbox                                   |
 | `blackbox_list_admins`              | List admins currently authorized for blackbox                           |
+| `blackbox_decrypt_file <file>`      | Decrypt a file                                                          |
 | `blackbox_decrypt_all_files`        | Decrypt all managed files (INTERACTIVE)                                 |
 | `blackbox_postdeploy`               | Decrypt all managed files (batch)                                       |
 | `blackbox_addadmin <gpg-key>`       | Add someone to the list of people that can encrypt/decrypt secrets      |

--- a/bin/blackbox_decrypt_file
+++ b/bin/blackbox_decrypt_file
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+#
+# blackbox_decrypt_file -- Decrypt one or more blackbox files.
+#
+
+set -e
+source "${0%/*}/_blackbox_common.sh"
+
+if [ $# -eq 0 ]; then
+  echo >&2 "Please provide at least one file to decrypt"
+  exit 1
+fi
+
+"${BLACKBOX_HOME}/blackbox_edit_start" "$@"


### PR DESCRIPTION
Add a command for decrypting single files. It is currently just an alias
for blackbox_edit_start.
It is meant to be a more obvious command for decrypting a single file
without editing it.

Fixes #268