### PR TITLE
Properly set the .blackbox as the default directory

### DIFF
--- a/bin/_blackbox_common.sh
+++ b/bin/_blackbox_common.sh
@@ -16,10 +16,13 @@ source "${0%/*}"/_stack_lib.sh
 : "${BLACKBOX_HOME:="$(cd "${0%/*}" ; pwd)"}" ;
 
 # What are the candidates for the blackbox data directory?
+#
+# The order of candidates matter. The first entry of the array
+# sets the default Blackbox directory for all new repositories.
 declare -a BLACKBOXDATA_CANDIDATES
 BLACKBOXDATA_CANDIDATES=(
-  'keyrings/live'
   '.blackbox'
+  'keyrings/live'
 )
 
 # If $EDITOR is not set, set it to "vi":


### PR DESCRIPTION
- _blackbox_common.sh sets the default Blackbox directory
  for the new repositories using the first entry of the
  BLACKBOX_CANDIDATES array. This small change sets the
  first entry to the new .blackbox dir (instead of the keyring/live),
  which in turn should create .blackbox dir during the blackbox_initialize
  step instead of the keyrings/live (as stated in README.md).