### PR TITLE
Add support for NetBSD and SunOS (SmartOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ BlackBox automatically determines which VCS you are using and does the right thi
   - MacOS X
   - Cygwin (Thanks, Ben Drasin!) **See Note Below**
   - MinGW (git bash on windows) **See Note Below**
+  - NetBSD
+  - SmartOS
 
 To add or fix support for a VCS system, look for code at the end of `bin/_blackbox_common.sh`
 

--- a/bin/_blackbox_common.sh
+++ b/bin/_blackbox_common.sh
@@ -411,6 +411,12 @@ function md5sum_file() {
     Darwin | FreeBSD )
       md5 -r "$1" | awk '{ print $1 }'
       ;;
+    NetBSD )
+      md5 -q "$1"
+      ;;
+    SunOS )
+      digest -a md5 "$1"
+      ;;
     Linux | CYGWIN* | MINGW* )
       md5sum "$1" | awk '{ print $1 }'
       ;;

--- a/bin/_blackbox_common.sh
+++ b/bin/_blackbox_common.sh
@@ -433,10 +433,13 @@ function cp_permissions() {
     Darwin )
       chmod $( stat -f '%p' "$1" ) "${@:2}"
       ;;
-    FreeBSD )
+    FreeBSD | NetBSD )
       chmod $( stat -f '%p' "$1" | sed -e "s/^100//" ) "${@:2}"
       ;;
-    Linux | CYGWIN* | MINGW* )
+    SunOS )
+      chmod $( stat -c '%a' "$1" ) "${@:2}"
+      ;;
+    Linux | CYGWIN* | MINGW* | SunOS )
       if [[ -e /etc/alpine-release ]]; then
         chmod $( stat -c '%a' "$1" ) "${@:2}"
       else

--- a/bin/_stack_lib.sh
+++ b/bin/_stack_lib.sh
@@ -57,7 +57,7 @@ function create_self_deleting_tempfile() {
       : "${TMPDIR:=/tmp}" ;
       filename=$(mktemp -t _stacklib_.XXXXXXXX )
       ;;
-    Linux | CYGWIN* | MINGW* )
+    Linux | CYGWIN* | MINGW* | NetBSD | SunOS )
       filename=$(mktemp)
       ;;
     * )
@@ -78,7 +78,7 @@ function create_self_deleting_tempdir() {
       : "${TMPDIR:=/tmp}" ;
       filename=$(mktemp -d -t _stacklib_.XXXXXXXX )
       ;;
-    Linux | CYGWIN* | MINGW* )
+    Linux | CYGWIN* | MINGW* | NetBSD | SunOS )
       filename=$(mktemp -d)
       ;;
     * )
@@ -102,7 +102,7 @@ function make_self_deleting_tempfile() {
       : "${TMPDIR:=/tmp}" ;
       name=$(mktemp -t _stacklib_.XXXXXXXX )
       ;;
-    Linux | CYGWIN* | MINGW* )
+    Linux | CYGWIN* | MINGW* | NetBSD | SunOS )
       name=$(mktemp)
       ;;
     * )
@@ -127,7 +127,7 @@ function make_tempdir() {
       # which needs to fit within sockaddr_un.sun_path (see unix(7)).
       name=$(mktemp -d -t SO )
       ;;
-    Linux | CYGWIN* | MINGW* )
+    Linux | CYGWIN* | MINGW* | NetBSD | SunOS )
       name=$(mktemp -d)
       ;;
     * )
@@ -160,14 +160,14 @@ function fail_if_not_running_as_root() {
 function fail_if_in_root_directory() {
   # Verify nobody has tricked us into being in "/".
   case $(uname -s) in
-    Darwin | FreeBSD )
+    Darwin | FreeBSD | NetBSD )
       if [[ $(stat -f'%i' / ) == $(stat -f'%i' . ) ]] ; then
         echo 'SECURITY ALERT: The current directory is the root directory.'
         echo 'Exiting...'
         exit 1
       fi
       ;;
-    Linux | CYGWIN* | MINGW* )
+    Linux | CYGWIN* | MINGW* | SunOS )
       if [[ $(stat -c'%i' / ) == $(stat -c'%i' . ) ]] ; then
         echo 'SECURITY ALERT: The current directory is the root directory.'
         echo 'Exiting...'

--- a/bin/blackbox_shred_all_files
+++ b/bin/blackbox_shred_all_files
@@ -45,6 +45,6 @@ if bash --help | grep import-functions >/dev/null 2>/dev/null; then
 fi
 
 export IFS=
-tr '\n' '\0' <"$BB_FILES" | xargs -0 -I{} -n 1 -P $MAX_PARALLEL_SHRED bash $bash_args -c "exported_internal_shred_file $DEREFERENCED_BIN_DIR \"{}\"" $DEREFERENCED_BIN_DIR/fake
+tr '\n' '\0' <"$BB_FILES" | xargs -0 -I{} -P $MAX_PARALLEL_SHRED bash $bash_args -c "exported_internal_shred_file $DEREFERENCED_BIN_DIR \"{}\"" $DEREFERENCED_BIN_DIR/fake
 
 echo '========== DONE.'

--- a/bin/blackbox_shred_all_files
+++ b/bin/blackbox_shred_all_files
@@ -39,7 +39,12 @@ export -f exported_internal_shred_file
 DEREFERENCED_BIN_DIR="${0%/*}"
 MAX_PARALLEL_SHRED=10
 
+bash_args=
+if bash --help | grep import-functions >/dev/null 2>/dev/null; then
+  bash_args=--import-functions
+fi
+
 export IFS=
-tr '\n' '\0' <"$BB_FILES" | xargs -0 -I{} -n 1 -P $MAX_PARALLEL_SHRED bash -c "exported_internal_shred_file $DEREFERENCED_BIN_DIR \"{}\"" $DEREFERENCED_BIN_DIR/fake
+tr '\n' '\0' <"$BB_FILES" | xargs -0 -I{} -n 1 -P $MAX_PARALLEL_SHRED bash $bash_args -c "exported_internal_shred_file $DEREFERENCED_BIN_DIR \"{}\"" $DEREFERENCED_BIN_DIR/fake
 
 echo '========== DONE.'

--- a/tools/confidence_test.sh
+++ b/tools/confidence_test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 blackbox_home=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../bin
-export PATH="${blackbox_home}:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/opt/local/bin:${blackbox_home}"
+export PATH="${blackbox_home}:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/opt/local/bin:/usr/pkg/bin:/usr/pkg/gnu/bin:${blackbox_home}"
 
 export LANG=C.UTF-8  # Required ro "gpg --export" to work properly.
 

--- a/tools/test_functions.sh
+++ b/tools/test_functions.sh
@@ -24,6 +24,12 @@ function md5sum_file() {
     Darwin | FreeBSD )
       md5 -r "$1" | awk '{ print $1 }'
       ;;
+    NetBSD )
+      md5 -q "$1"
+      ;;
+    SunOS )
+      digest -a md5 "$1"
+      ;;
     Linux )
       md5sum "$1" | awk '{ print $1 }'
       ;;
@@ -72,10 +78,10 @@ function assert_file_group() {
   assert_file_exists "$file"
 
   case $(uname -s) in
-    Darwin|FreeBSD )
+    Darwin | FreeBSD | NetBSD )
       found=$(stat -f '%Dg' "$file")
       ;;
-    Linux )
+    Linux | SunOS )
       found=$(stat -c '%g' "$file")
       ;;
     CYGWIN* )
@@ -102,11 +108,11 @@ function assert_file_perm() {
   assert_file_exists "$file"
 
   case $(uname -s) in
-    Darwin|FreeBSD )
+    Darwin | FreeBSD | NetBSD )
       found=$(stat -f '%Sp' "$file")
       ;;
     # NB(tlim): CYGWIN hasn't been tested. It might be more like Darwin.
-    Linux | CYGWIN* )
+    Linux | CYGWIN* | SunOS )
       found=$(stat -c '%A' "$file")
       ;;
     * )


### PR DESCRIPTION
This PR includes changes needed to support NetBSD and SmartOS. Pretty minimal changes with the exception of `` bin/blackbox_shred_all_files`` where [Pkgsrc has patched bash](https://www.mail-archive.com/smartos-discuss@lists.smartos.org/msg01247.html) to require an ``--import-functions`` flag in order to use exported functions.

Let me know if you'd also like me to include the ``make confidence`` output from NetBSD and SmartOS. Both successfully pass the tests provided they are run as root. Commenting out the test that runs ``chgrp`` (permission denied because the user running the test is not in the target group) allows the test to pass as a regular user.