### PR TITLE
Promote 'getting started' to a section, enumerate steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,20 +53,26 @@ Rather than one GPG passphrase for all the files, each person with access has th
 
 Automated processes often need access to all the decrypted files. This is easy too. For example, suppose Git is being used for Puppet files. The master needs access to the decrypted version of all the files. Simply set up a GPG key for the Puppet master (or the role account that pushes new files to the Puppet master) and have that user run `blackbox_postdeploy` after any files are updated.
 
-Getting started is looks like this.
-First, if you don't have a GPG key, set it up using instructions
-such as:
-[Set up GPG key](https://help.github.com/articles/generating-a-new-gpg-key/).
+Getting started
+---------------
+
+1. If you don't have a GPG key, set it up using instructions such as:
+[Set up GPG key](https://help.github.com/articles/generating-a-new-gpg-key/). \
 Now you are ready to go.
-`cd` into a Git, Mercurial, Subversion
-or Perforce repository and run `blackbox_initialize`. After that,
-if a file is to be encrypted, run `blackbox_register_new_file` and
-you are done. Add and remove keys with `blackbox_addadmin` and
-`blackbox_removeadmin`. To view and/or edit a file, run `blackbox_edit`;
+
+1. `cd` into a Git, Mercurial, Subversion or Perforce repository and run `blackbox_initialize`.
+
+1. If a file is to be encrypted, run `blackbox_register_new_file` and you are done.
+
+1. Add and remove keys with `blackbox_addadmin` and `blackbox_removeadmin`.
+
+1. To view and/or edit a file, run `blackbox_edit`;
 this will decrypt the file and open with whatever is specified by
-your $EDITOR environment variable. When you close the editor the
+your $EDITOR environment variable. \
+When you close the editor the
 file will automatically be encrypted again and the temporary plaintext
-file will be shredded. If you need to leave the file decrypted while
+file will be shredded. \
+If you need to leave the file decrypted while
 you update you can use the`blackbox_edit_start` to decrypt the file
 and `blackbox_edit_end` when you want to "put it back in the box."
 


### PR DESCRIPTION
Explicitly wrap lines in sub-paragraphs with '\'.

This is an attempt to have "getting started" stan out and improve
user-approachability (admittedly, subjective).

Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>