### PR TITLE
Fix Windows compatibility for blackbox_addadmin and blackbox_register_new_file

### DIFF
--- a/bin/_blackbox_common.sh
+++ b/bin/_blackbox_common.sh
@@ -213,7 +213,8 @@ function add_filename_to_cryptlist() {
   else
     echo "========== Adding file to list."
     touch "$BB_FILES"
-    sort -u -o "$BB_FILES" <(echo "$name") "$BB_FILES"
+    echo "$name" >> "$BB_FILES"
+    sort -u -o "$BB_FILES" "$BB_FILES"
   fi
 }
 

--- a/bin/blackbox_addadmin
+++ b/bin/blackbox_addadmin
@@ -19,7 +19,8 @@ KEYNAME="$1"
 # Add the email address to the BB_ADMINS file.  Remove any duplicates.
 # The file must exist for sort to act as we expect.
 touch "$BB_ADMINS"
-sort  -fdu -o "$BB_ADMINS" <(echo "$1") "$BB_ADMINS"
+echo "$1" >> "$BB_ADMINS"
+sort -fdu -o "$BB_ADMINS" "$BB_ADMINS"
 
 
 # Add the user's key to the keychain.


### PR DESCRIPTION
Running on Windows 10 MinGW. Followed the recommended settings in README.md. 
Bash now needs fdescfs mounted at /dev/fd. Which MinGW doesn't do.
It means scripts that use process substitution fail with: /dev/fd/63: No such file or directory.

Both blackbox_addadmin and registering new files failed with this setup, making blackbox unusable. This PR addresses those scripts.

This change doesn't fix blackbox_diff or blackbox_whatsnew since the diff command within those scripts requires files as args and I didn't want to mess with temp files, but this does at least fix main scripts on Windows to get basic functionality.
