### PR TITLE
Documentation: Add pkgsrc install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Installation Instructions
 - *The Antigen Way*: Add `antigen bundle StackExchange/blackbox` to your .zshrc
 - *The Zgen Way*: Add `zgen load StackExchange/blackbox` to your .zshrc where you're loading your other plugins.
 - *The Nix Way*: `nix-env -i blackbox`
+- *The Pkgsrc Way*: `pkgin in scm-blackbox`
 
 Commands
 ========


### PR DESCRIPTION
Available in pkgsrc (via pkgin) as [scm-blackbox](http://pkgsrc.se/security/scm-blackbox) 

Just noticed that I forgot to do this along with #277