### PR TITLE
Go version: run build checks & tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,3 +22,5 @@ jobs:
     - name: Build binaries
       working-directory: cmd/blackbox
       run: go build
+    - name: Run unit tests
+      run: go test ./...

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,4 +21,4 @@ jobs:
         go-version: ^1.15
     - name: Build binaries
       working-directory: cmd/blackbox
-      run: go run build/build.go
+      run: go build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: build
+
+on: 
+  pull_request:
+    branches: [ master ]
+  push:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.15
+    - name: Build binaries
+      working-directory: cmd/blackbox
+      run: go run build/build.go

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,4 +26,4 @@ jobs:
       run: go test ./...
     - name: Run integration tests
       working-directory: integrationTest
-      run: go test -long --nocleanup
+      run: umask 0027 ; rm -rf /tmp/bbhome-* && go test -long -nocleanup

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,3 +24,6 @@ jobs:
       run: go build
     - name: Run unit tests
       run: go test ./...
+    - name: Run integration tests
+      working-directory: integrationTest
+      run: go test -long --nocleanup

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-BlackBox [![CircleCI](https://circleci.com/gh/StackExchange/blackbox.svg?style=shield)](https://circleci.com/gh/StackExchange/workflows/blackbox)
+BlackBox [![CircleCI](https://circleci.com/gh/StackExchange/blackbox.svg?style=shield)](https://circleci.com/gh/StackExchange/workflows/blackbox) [![Build Status](https://github.com/StackExchange/blackbox/workflows/build/badge.svg)](https://github.com/StackExchange/blackbox/actions?query=workflow%3Abuild+branch%3Amaster)
+
 ========
 
 Safely store secrets in a VCS repo (i.e. Git, Mercurial, Subversion or Perforce). These commands make it easy for you to Gnu Privacy Guard (GPG) encrypt specific files in a repo so they are "encrypted at rest" in your repository. However, the scripts make it easy to decrypt them when you need to view or edit them, and decrypt them for use in production. Originally written for Puppet, BlackBox now works with any Git or Mercurial repository.


### PR DESCRIPTION
Analogous to the existing circleci build checks for the Bash version, this adds a GitHub Actions workflow to run build checks & unit/integration tests for the Go version (https://github.com/StackExchange/blackbox/issues/310).