### PR TITLE
Fix 'chmod' for macOS

### DIFF
--- a/bin/_blackbox_common.sh
+++ b/bin/_blackbox_common.sh
@@ -432,7 +432,7 @@ function cp_permissions() {
   # Copy the perms of $1 onto $2 .. end.
   case $(uname -s) in
     Darwin )
-      chmod $( stat -f '%p' "$1" ) "${@:2}"
+      chmod $( stat -f '%Lp' "$1" ) "${@:2}"
       ;;
     FreeBSD | NetBSD )
       chmod $( stat -f '%p' "$1" | sed -e "s/^100//" ) "${@:2}"


### PR DESCRIPTION
`stat -f '%p'` returns groups and permissions (`100644`) which does not work for `chmod`

`stat -f '%Lp'` returns only permissions (`644`)

Related to issue:  https://github.com/StackExchange/blackbox/issues/346