### PR TITLE
Update zgen reference to use zgenom

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Installation Instructions
 - *The RPM way*: Check out the repo and make an RPM via `make packages-rpm`; now you can distribute the RPM via local methods. (Requires [fpm](https://github.com/jordansissel/fpm).)
 - *The Debian/Ubuntu way*: Check out the repo and make a DEB via `make packages-deb`; now you can distribute the DEB via local methods. (Requires [fpm](https://github.com/jordansissel/fpm).)
 - *The Antigen Way*: Add `antigen bundle StackExchange/blackbox` to your .zshrc
-- *The Zgen Way*: Add `zgen load StackExchange/blackbox` to your .zshrc where you're loading your other plugins.
+- *The Zgenom Way*: Add `zgenom load StackExchange/blackbox` to your .zshrc where you're loading your other plugins.
 - *The Nix Way*: `nix-shell -p blackbox`
 - *The Pkgsrc Way*: `pkgin in scm-blackbox`
 


### PR DESCRIPTION
zgen hasn't been updated in three years. Zgenom is a fork that is being actively maintained.
