### PR TITLE
don't bypass the web of trust (#378)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Table of Contents
 - User Management
   - [How to indoctrinate a new user into the system?](#how-to-indoctrinate-a-new-user-into-the-system)
   - [How to remove a user from the system?](#how-to-remove-a-user-from-the-system)
+  - [Note to the Web Of Trust](#note-to-the-web-of-trust)
 - Repo Management
   - [Enabling BlackBox For a Repo](#enabling-blackbox-for-a-repo)
 - [Set up automated users or &ldquo;role accounts&rdquo;](#set-up-automated-users-or-role-accounts)
@@ -481,6 +482,19 @@ FYI: Your repo may use `keyrings/live` instead of `.blackbox`. See "Where is the
 The key ring only has public keys. There are no secret keys to delete.
 
 Remember that this person did have access to all the secrets at one time. They could have made a copy. Therefore, to be completely secure, you should change all passwords, generate new SSL keys, and so on just like when anyone that had privileged access leaves an organization.
+
+Note to the Web Of Trust
+========================
+
+Validating the trustworthiness of keys is a task that can't be accomplished by Blackbox; this is a completely external topic that has to be dealt with manually (the same way as generating/managing your key is, for example) or by a dedicated mechanism (a company CA with corresponding workflows e.g.). Aside from the "common" benefits of a Web Of Trust (see [here](https://www.gnupg.org/gph/en/manual/x334.html) or [here](https://www.gnupg.org/gph/en/manual/x547.html) e.g.), it prevents several errors as well.
+
+Historically Blackbox was using and enforcing a "trust every key" model but this has changed! Now the decision of whether and how to use the PGP/GPG trust models is left up to the user by configuration (or by the PGP/GPG defaults).  
+When updating Blackbox people might run into functional problems if they haven't yet dealt with the trustability of the keys they're using. It's the right time to do so and built up your Web Of Trust now!
+
+If you have an external workflow in place that ensures the integrity of the keys Blackbox uses you might want to disable the PGP/GPG trust models and rely on this workflow.  
+This can be achieved by declaring "trust model always", either by passing the command line parameter `--trust-model=always` to your PGP/GPG binary when using Blackbox (by defining an alias or using the environment variable (e.g. `GPG="gpg2 --trust-model=always"`) or a combination of both) or by setting `trust-model always` in your `gpg.conf` (note that this disables the Web Of Trust everywhere, not just for Blackbox).
+
+WARNING: It is strongly disadvised to not use any key validation at all! This opens up various ways to bypass the confidentiality of your encrypted secrets!
 
 Where is the configuration stored? .blackbox vs. keyrings/live
 ==============================================================

--- a/bin/_blackbox_common.sh
+++ b/bin/_blackbox_common.sh
@@ -253,7 +253,7 @@ function encrypt_file() {
   encrypted="$2"
 
   echo "========== Encrypting: $unencrypted" >&2
-  $GPG --use-agent --yes --trust-model=always --encrypt -o "$encrypted"  $(awk '{ print "-r" $1 }' < "$BB_ADMINS") "$unencrypted" >&2
+  $GPG --use-agent --yes --encrypt -o "$encrypted"  $(awk '{ print "-r" $1 }' < "$BB_ADMINS") "$unencrypted" >&2
   echo '========== Encrypting: DONE' >&2
 }
 

--- a/integrationTest/ithelpers.go
+++ b/integrationTest/ithelpers.go
@@ -421,13 +421,8 @@ Expire-Date: 0
 
 func hasQuick(t *testing.T) bool {
 	testing.Init()
-	fmt.Println("========== Do we have --quick-generate-key?")
-	err := bbutil.RunBash("gpg2",
-		"--dry-run",
-		"--quick-generate-key",
-		"--batch",
-		"--passphrase", "",
-		"foo", "rsa", "encr")
+	fmt.Println("========== Do we run gpg2?")
+	err := bbutil.RunBash("gpg2", "--version")
 	fmt.Println("========== Done")
 	if err == nil {
 		return true

--- a/pkg/crypters/gnupg/gnupg.go
+++ b/pkg/crypters/gnupg/gnupg.go
@@ -106,7 +106,6 @@ func (crypt CrypterHandle) Encrypt(filename string, umask int, receivers []strin
 	a := []string{
 		"--use-agent",
 		"--yes",
-		"--trust-model=always",
 		"--encrypt",
 		"-o", encrypted,
 	}


### PR DESCRIPTION
the choice whether to use a web of trust and on which trust level is up to the user of PGP/GPG and must not be overriden by tools that are set on top

users can decide to ignore this safety net by setting their gpg.conf adequately, defining an alias for `gpg --trust-model=always` or passing the env GPG to blackbox in this way but we should not override their preferences hardcoded